### PR TITLE
Refactor modem UART RX ownership and AT transport

### DIFF
--- a/platform/src/modem-at/inc/modem-at.h
+++ b/platform/src/modem-at/inc/modem-at.h
@@ -25,7 +25,24 @@ struct modem_at_diagnostics {
 	int lastUartRet;
 };
 
+struct modem_at_irq_transport {
+	void *ctx;
+	int (*open)(void *ctx, char *response, size_t responseSize);
+	void (*close)(void *ctx);
+	uint32_t (*read)(void *ctx, uint8_t *buffer, size_t bufferSize);
+};
+
+struct modem_at_irq_debug {
+	void *ctx;
+	void (*log)(void *ctx, const char *fmt, ...);
+};
+
 int modem_at_send(const char *command, char *response, size_t responseSize);
+int modem_at_send_irq(const char *command,
+		     char *response,
+		     size_t responseSize,
+		     const struct modem_at_irq_transport *transport,
+		     const struct modem_at_irq_debug *debug);
 int modem_at_uart_write(const uint8_t *data, size_t length);
 int modem_at_uart_read_byte(uint8_t *byte);
 bool modem_at_uart_is_ready(void);

--- a/platform/src/modem-at/modem-at.c
+++ b/platform/src/modem-at/modem-at.c
@@ -1,7 +1,9 @@
 #include "modem-at.h"
 
 #include <errno.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <zephyr/device.h>
@@ -12,6 +14,7 @@
 #define MODEM_AT_RESPONSE_TIMEOUT_MS 5000
 #define MODEM_AT_INTER_CHAR_TIMEOUT_MS 1000
 #define MODEM_AT_PRE_SEND_FLUSH_MS 50
+#define MODEM_AT_IRQ_RX_CHUNK_SIZE 64
 
 static const struct device *const modemUart = DEVICE_DT_GET(MODEM_UART_NODE);
 static struct modem_at_diagnostics lastDiagnostics;
@@ -82,6 +85,88 @@ static int response_append(char *response, size_t responseSize, size_t *length, 
 	return 0;
 }
 
+static void modem_at_irq_debug_log(const struct modem_at_irq_debug *debug, const char *fmt, ...)
+{
+	if ((debug == NULL) || (debug->log == NULL)) {
+		return;
+	}
+
+	char buffer[256];
+	va_list args;
+
+	va_start(args, fmt);
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+	va_end(args);
+
+	debug->log(debug->ctx, "%s", buffer);
+}
+
+static int modem_at_irq_write_command(const char *command, const struct modem_at_irq_debug *debug)
+{
+	int ret = modem_at_uart_write((const uint8_t *)command, strlen(command));
+	modem_at_irq_debug_log(debug, "[modem-at irq] command write ret=%d len=%u", ret,
+			      (unsigned int)strlen(command));
+	if (ret == 0) {
+		static const uint8_t cr = '\r';
+		ret = modem_at_uart_write(&cr, 1U);
+		modem_at_irq_debug_log(debug, "[modem-at irq] CR write ret=%d", ret);
+	}
+	return ret;
+}
+
+static int modem_at_irq_collect_response(char *response,
+					 size_t responseSize,
+					 const struct modem_at_irq_transport *transport,
+					 const struct modem_at_irq_debug *debug)
+{
+	size_t offset = 0U;
+	bool loggedFirstRx = false;
+	int64_t deadline = k_uptime_get() + MODEM_AT_RESPONSE_TIMEOUT_MS;
+
+	for (;;) {
+		uint8_t chunk[MODEM_AT_IRQ_RX_CHUNK_SIZE];
+		uint32_t received = transport->read(transport->ctx, chunk, sizeof(chunk));
+		if (received > 0U) {
+			if (!loggedFirstRx) {
+				modem_at_irq_debug_log(debug,
+						"[modem-at irq] first rx chunk bytes=%u first=0x%02X",
+						(unsigned int)received,
+						(unsigned int)chunk[0]);
+				loggedFirstRx = true;
+			}
+			for (uint32_t i = 0; i < received; ++i) {
+				if (offset + 1U < responseSize) {
+					response[offset++] = (char)chunk[i];
+					response[offset] = '\0';
+				}
+			}
+
+			if ((strstr(response, "\r\nOK\r\n") != NULL) ||
+			    (strstr(response, "\nOK\r\n") != NULL) ||
+			    (strstr(response, "\nOK\n") != NULL)) {
+				modem_at_irq_debug_log(debug, "[modem-at irq] success bytes=%u",
+						(unsigned int)offset);
+				return 0;
+			}
+			if (strstr(response, "ERROR") != NULL) {
+				modem_at_irq_debug_log(debug, "[modem-at irq] modem error bytes=%u",
+						(unsigned int)offset);
+				return -EIO;
+			}
+
+			deadline = k_uptime_get() + MODEM_AT_INTER_CHAR_TIMEOUT_MS;
+			continue;
+		}
+
+		if (k_uptime_get() >= deadline) {
+			modem_at_irq_debug_log(debug, "[modem-at irq] timeout bytes=%u", (unsigned int)offset);
+			return -ETIMEDOUT;
+		}
+
+		k_msleep(10);
+	}
+}
+
 bool modem_at_uart_is_ready(void)
 {
 	return device_is_ready(modemUart);
@@ -115,6 +200,40 @@ int modem_at_uart_read_byte(uint8_t *byte)
 	}
 
 	return uart_poll_in(modemUart, byte);
+}
+
+int modem_at_send_irq(const char *command,
+		     char *response,
+		     size_t responseSize,
+		     const struct modem_at_irq_transport *transport,
+		     const struct modem_at_irq_debug *debug)
+{
+	modem_at_irq_debug_log(debug, "[modem-at irq] enter cmd='%s'", command != NULL ? command : "<null>");
+
+	if ((command == NULL) || (response == NULL) || (responseSize == 0U) || (transport == NULL) ||
+	    (transport->open == NULL) || (transport->close == NULL) || (transport->read == NULL)) {
+		modem_at_irq_debug_log(debug, "[modem-at irq] invalid args");
+		return -EINVAL;
+	}
+
+	int ret = transport->open(transport->ctx, response, responseSize);
+	if (ret != 0) {
+		modem_at_irq_debug_log(debug, "[modem-at irq] prepare/acquire failed ret=%d", ret);
+		return ret;
+	}
+
+	modem_at_irq_debug_log(debug, "[modem-at irq] rx session acquired");
+
+	ret = modem_at_irq_write_command(command, debug);
+	if (ret != 0) {
+		transport->close(transport->ctx);
+		modem_at_irq_debug_log(debug, "[modem-at irq] write failed ret=%d", ret);
+		return ret;
+	}
+
+	ret = modem_at_irq_collect_response(response, responseSize, transport, debug);
+	transport->close(transport->ctx);
+	return ret;
 }
 
 int modem_at_send(const char *command, char *response, size_t responseSize)

--- a/platform/src/modem-shell/modem-shell-core.c
+++ b/platform/src/modem-shell/modem-shell-core.c
@@ -120,14 +120,22 @@ int modem_shell_cmd_power_core(const struct modem_shell_ops *ops, size_t argc, c
 int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char **argv)
 {
 	struct modem_board_status st;
-	struct modem_at_diagnostics diagnostics;
-	char response[256];
+	struct modem_at_diagnostics diagnostics = {0};
+	char response[256] = {0};
+	const char *command;
+	size_t commandIndex = 1U;
 	int ret;
 
-	if (argc < 2U) {
-		ops->error(ops->ctx, "usage: at <command>");
+	if ((argc >= 2U) && (strcmp(argv[1], "--debug") == 0)) {
+		commandIndex = 2U;
+	}
+
+	if (argc <= commandIndex) {
+		ops->error(ops->ctx, "usage: at [--debug] <command>");
 		return -EINVAL;
 	}
+
+	command = argv[commandIndex];
 
 	ret = ops->modem_board_get_status(&st);
 	if (ret != 0) {
@@ -143,10 +151,10 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 	int (*send_fn)(const char *command, char *response, size_t responseSize) =
 		ops->modem_at_send_runtime != NULL ? ops->modem_at_send_runtime : ops->modem_at_send;
 
-	ret = send_fn(argv[1], response, sizeof(response));
+	ret = send_fn(command, response, sizeof(response));
 	modem_at_get_last_diagnostics(&diagnostics);
 	if (ret != 0) {
-		if (response[0] != '\0') {
+		if (ops->modemAtDebug && (response[0] != '\0')) {
 			ops->error(ops->ctx,
 				"[raw modem response on error]\n%s\n[modem-at] exit=%s bytes=%u ret=%d",
 				response,
@@ -154,29 +162,39 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 				(unsigned int)diagnostics.bytesReceived,
 				ret);
 		} else if (ret == -ETIMEDOUT) {
-			ops->error(ops->ctx,
-				"AT command timed out waiting for modem response (exit=%s, bytes=%u)",
-				modem_at_exit_reason_str(diagnostics.exitReason),
-				(unsigned int)diagnostics.bytesReceived);
-		} else {
+			if (ops->modemAtDebug) {
+				ops->error(ops->ctx,
+					"AT command timed out waiting for modem response (exit=%s, bytes=%u)",
+					modem_at_exit_reason_str(diagnostics.exitReason),
+					(unsigned int)diagnostics.bytesReceived);
+			} else {
+				ops->error(ops->ctx, "AT command timed out waiting for modem response");
+			}
+		} else if (ops->modemAtDebug) {
 			ops->error(ops->ctx,
 				"AT command failed: %d (exit=%s, bytes=%u)",
 				ret,
 				modem_at_exit_reason_str(diagnostics.exitReason),
 				(unsigned int)diagnostics.bytesReceived);
+		} else {
+			ops->error(ops->ctx, "AT command failed: %d", ret);
 		}
 		return ret;
 	}
 
 	if (response[0] == '\0') {
-		ops->print(ops->ctx,
-			"[empty modem response]\n[modem-at] exit=%s bytes=%u",
-			modem_at_exit_reason_str(diagnostics.exitReason),
-			(unsigned int)diagnostics.bytesReceived);
+		if (ops->modemAtDebug) {
+			ops->print(ops->ctx,
+				"[empty modem response]\n[modem-at] exit=%s bytes=%u",
+				modem_at_exit_reason_str(diagnostics.exitReason),
+				(unsigned int)diagnostics.bytesReceived);
+		} else {
+			ops->print(ops->ctx, "[empty modem response]");
+		}
 		return 0;
 	}
 
-	if (strcmp(response, argv[1]) == 0) {
+	if (ops->modemAtDebug && (strcmp(response, command) == 0)) {
 		ops->print(ops->ctx,
 			"[echo only]\n%s\n[modem-at] exit=%s bytes=%u",
 			response,
@@ -185,10 +203,14 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 		return 0;
 	}
 
-	ops->print(ops->ctx,
-		"[raw modem response]\n%s\n[modem-at] exit=%s bytes=%u",
-		response,
-		modem_at_exit_reason_str(diagnostics.exitReason),
-		(unsigned int)diagnostics.bytesReceived);
+	if (ops->modemAtDebug) {
+		ops->print(ops->ctx,
+			"[raw modem response]\n%s\n[modem-at] exit=%s bytes=%u",
+			response,
+			modem_at_exit_reason_str(diagnostics.exitReason),
+			(unsigned int)diagnostics.bytesReceived);
+	} else {
+		ops->print(ops->ctx, "%s", response);
+	}
 	return 0;
 }

--- a/platform/src/modem-shell/modem-shell-core.c
+++ b/platform/src/modem-shell/modem-shell-core.c
@@ -8,19 +8,59 @@
 #define MODEM_AT_SYNC_COMMAND "AT"
 #define MODEM_AT_DISABLE_SLEEP_COMMAND "AT+KSLEEP=2"
 
+typedef int (*modem_shell_at_send_fn_t)(const char *command, char *response, size_t responseSize);
+
+enum modem_shell_at_send_mode {
+	MODEM_SHELL_AT_SEND_MODE_RUNTIME = 0,
+	MODEM_SHELL_AT_SEND_MODE_POWER_ON,
+};
+
+static modem_shell_at_send_fn_t modem_shell_select_at_sender(const struct modem_shell_ops *ops,
+					     enum modem_shell_at_send_mode mode)
+{
+	if ((mode == MODEM_SHELL_AT_SEND_MODE_POWER_ON) && (ops->modem_at_send_power_on != NULL)) {
+		return ops->modem_at_send_power_on;
+	}
+
+	if (ops->modem_at_send_runtime != NULL) {
+		return ops->modem_at_send_runtime;
+	}
+
+	return ops->modem_at_send;
+}
+
+static int modem_shell_run_at_command(const struct modem_shell_ops *ops,
+				      enum modem_shell_at_send_mode mode,
+				      const char *command,
+				      char *response,
+				      size_t responseSize)
+{
+	modem_shell_at_send_fn_t send_fn = modem_shell_select_at_sender(ops, mode);
+	if (send_fn == NULL) {
+		ops->error(ops->ctx,
+			(mode == MODEM_SHELL_AT_SEND_MODE_POWER_ON) ?
+				"no modem AT sender configured for power-on flow" :
+				"no modem AT sender configured for runtime AT command");
+		return -ENOSYS;
+	}
+
+	return send_fn(command, response, responseSize);
+}
+
 static int modem_shell_disable_sleep_after_power_on(const struct modem_shell_ops *ops)
 {
 	char response[256];
 	int ret = -ETIMEDOUT;
-	int (*send_fn)(const char *command, char *response, size_t responseSize) =
-		ops->modem_at_send_power_on != NULL ? ops->modem_at_send_power_on :
-		(ops->modem_at_send_runtime != NULL ? ops->modem_at_send_runtime : ops->modem_at_send);
 
 	ops->print(ops->ctx, "Waiting 10s for modem boot...");
 	ops->sleep_ms(MODEM_AT_BOOT_DELAY_MS);
 
 	for (int attempt = 0; attempt < MODEM_AT_SYNC_RETRIES; ++attempt) {
-		ret = send_fn(MODEM_AT_SYNC_COMMAND, response, sizeof(response));
+		ret = modem_shell_run_at_command(ops,
+					       MODEM_SHELL_AT_SEND_MODE_POWER_ON,
+					       MODEM_AT_SYNC_COMMAND,
+					       response,
+					       sizeof(response));
 		if (ret == 0) {
 			break;
 		}
@@ -32,7 +72,11 @@ static int modem_shell_disable_sleep_after_power_on(const struct modem_shell_ops
 	}
 
 	ops->print(ops->ctx, "Disabling sleep...");
-	ret = send_fn(MODEM_AT_DISABLE_SLEEP_COMMAND, response, sizeof(response));
+	ret = modem_shell_run_at_command(ops,
+					 MODEM_SHELL_AT_SEND_MODE_POWER_ON,
+					 MODEM_AT_DISABLE_SLEEP_COMMAND,
+					 response,
+					 sizeof(response));
 	if (ret != 0) {
 		ops->error(ops->ctx, "failed to disable modem sleep: %d", ret);
 		return ret;
@@ -148,10 +192,11 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 		return -EHOSTDOWN;
 	}
 
-	int (*send_fn)(const char *command, char *response, size_t responseSize) =
-		ops->modem_at_send_runtime != NULL ? ops->modem_at_send_runtime : ops->modem_at_send;
-
-	ret = send_fn(command, response, sizeof(response));
+	ret = modem_shell_run_at_command(ops,
+					 MODEM_SHELL_AT_SEND_MODE_RUNTIME,
+					 command,
+					 response,
+					 sizeof(response));
 	modem_at_get_last_diagnostics(&diagnostics);
 	if (ret != 0) {
 		if (ops->modemAtDebug && (response[0] != '\0')) {

--- a/platform/src/modem-shell/modem-shell-core.h
+++ b/platform/src/modem-shell/modem-shell-core.h
@@ -3,6 +3,7 @@
 #include "modem-at.h"
 #include "modem-board.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -23,6 +24,7 @@ struct modem_shell_ops {
 	void (*print)(void *ctx, const char *fmt, ...);
 	void (*error)(void *ctx, const char *fmt, ...);
 	void *ctx;
+	bool modemAtDebug;
 };
 
 int modem_shell_cmd_status_core(const struct modem_shell_ops *ops);

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -56,7 +56,7 @@ static void shell_sleep_ms_adapter(int32_t durationMs)
 static const struct device *const modemUart = DEVICE_DT_GET(DT_NODELABEL(modem_uart));
 static const struct shell *passthroughShell;
 static bool passthroughActive;
-static bool passthroughHexMode;
+static bool passthroughDebugMode;
 static uint8_t passthroughTail;
 static K_THREAD_STACK_DEFINE(passthroughStack, MODEM_PASSTHROUGH_STACK_SIZE);
 static struct k_thread passthroughThread;
@@ -194,6 +194,7 @@ static const struct modem_shell_ops shellOps = {
 	.sleep_ms = shell_sleep_ms_adapter,
 	.print = shell_print_adapter,
 	.error = shell_error_adapter,
+	.modemAtDebug = false,
 };
 
 static void modem_passthrough_stop(void)
@@ -208,7 +209,7 @@ static void modem_passthrough_stop(void)
 	shell_print(passthroughShell, "\r\n[modem passthrough disabled]");
 	passthroughShell = NULL;
 	passthroughTail = 0U;
-	passthroughHexMode = false;
+	passthroughDebugMode = false;
 	ring_buf_reset(&passthroughIrqRing);
 }
 
@@ -308,7 +309,7 @@ static void modem_passthrough_rx_thread(void *arg1, void *arg2, void *arg3)
 		uint8_t buffer[MODEM_PASSTHROUGH_RX_CHUNK_SIZE];
 		uint32_t length = ring_buf_get(&passthroughIrqRing, buffer, sizeof(buffer));
 		if (length > 0U) {
-			if (passthroughHexMode) {
+			if (passthroughDebugMode) {
 				modem_passthrough_trace_chunk(passthroughShell, buffer, length);
 			} else {
 				modem_passthrough_print_text_chunk(passthroughShell, buffer, length);
@@ -386,7 +387,8 @@ static int cmd_modem_at(const struct shell *sh, size_t argc, char **argv)
 {
 	struct modem_shell_ops ops = shellOps;
 	ops.ctx = (void *)sh;
-	modemAtDebugShell = sh;
+	ops.modemAtDebug = (argc >= 2U) && (strcmp(argv[1], "--debug") == 0);
+	modemAtDebugShell = ops.modemAtDebug ? sh : NULL;
 	int ret = modem_shell_cmd_at_core(&ops, argc, argv);
 	modemAtDebugShell = NULL;
 	return ret;
@@ -394,13 +396,13 @@ static int cmd_modem_at(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **argv)
 {
-	bool hexMode = false;
+	bool debugMode = false;
 
 	if (argc >= 2U) {
-		if (strcmp(argv[1], "--hex") == 0) {
-			hexMode = true;
+		if (strcmp(argv[1], "--debug") == 0) {
+			debugMode = true;
 		} else {
-			shell_error(sh, "usage: modem passthrough [--hex]");
+			shell_error(sh, "usage: modem passthrough [--debug]");
 			return -EINVAL;
 		}
 	}
@@ -450,12 +452,12 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 	ring_buf_reset(&passthroughIrqRing);
 	passthroughShell = sh;
 	passthroughTail = 0U;
-	passthroughHexMode = hexMode;
+	passthroughDebugMode = debugMode;
 	passthroughActive = true;
 	uart_irq_rx_enable(modemUart);
 	shell_print(sh,
-		    hexMode ? "Entering modem UART passthrough (hex mode). Press Ctrl-X then Ctrl-Q to exit."
-		            : "Entering modem UART passthrough. Press Ctrl-X then Ctrl-Q to exit.");
+		    debugMode ? "Entering modem UART passthrough (debug mode). Press Ctrl-X then Ctrl-Q to exit."
+		              : "Entering modem UART passthrough. Press Ctrl-X then Ctrl-Q to exit.");
 	shell_set_bypass(sh, modem_passthrough_bypass_cb);
 	return 0;
 }
@@ -464,9 +466,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD(status, NULL, "Print modem GPIO status", cmd_modem_status),
 	SHELL_CMD(reset, NULL, "Pulse modem reset (MODEM_nRST)", cmd_modem_reset),
 	SHELL_CMD_ARG(power, NULL, "Modem power control: power <on|off|cycle>", cmd_modem_power, 2, 0),
-	SHELL_CMD_ARG(at, NULL, "Send AT command: at <command>", cmd_modem_at, 2, 0),
+	SHELL_CMD_ARG(at, NULL, "Send AT command: at [--debug] <command>", cmd_modem_at, 2, 1),
 	SHELL_CMD_ARG(passthrough, NULL,
-		      "Raw UART passthrough to modem. Use --hex for RX trace mode; Ctrl-X then Ctrl-Q exits.",
+		      "Raw UART passthrough to modem. Use --debug for RX trace mode; Ctrl-X then Ctrl-Q exits.",
 		      cmd_modem_passthrough, 1, 1),
 	SHELL_SUBCMD_SET_END /* Array terminator */
 );

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -20,7 +20,7 @@
 #define MODEM_PASSTHROUGH_ESCAPE_SUFFIX 0x11u
 #define MODEM_PASSTHROUGH_RX_CHUNK_SIZE 64
 #define MODEM_PASSTHROUGH_RX_TRACE_BUFFER_SIZE (MODEM_PASSTHROUGH_RX_CHUNK_SIZE * 3U + 1U)
-#define MODEM_PASSTHROUGH_IRQ_RING_SIZE 512
+#define MODEM_UART_RX_RING_SIZE 512
 
 static void shell_print_adapter(void *ctx, const char *fmt, ...)
 {
@@ -61,13 +61,99 @@ static uint8_t passthroughTail;
 static K_THREAD_STACK_DEFINE(passthroughStack, MODEM_PASSTHROUGH_STACK_SIZE);
 static struct k_thread passthroughThread;
 static bool passthroughThreadStarted;
-static uint8_t passthroughIrqRingBuffer[MODEM_PASSTHROUGH_IRQ_RING_SIZE];
-static struct ring_buf passthroughIrqRing;
-static bool passthroughIrqConfigured;
+static uint8_t modemUartRxRingBuffer[MODEM_UART_RX_RING_SIZE];
+static struct ring_buf modemUartRxRing;
+static bool modemUartRxIrqConfigured;
 static const struct shell *modemAtDebugShell;
 
-static void modem_at_debug_log(const char *fmt, ...)
+enum modem_uart_rx_owner {
+	MODEM_UART_RX_OWNER_NONE = 0,
+	MODEM_UART_RX_OWNER_AT,
+	MODEM_UART_RX_OWNER_PASSTHROUGH,
+};
+
+static enum modem_uart_rx_owner modemUartRxOwner;
+
+static void modem_uart_rx_irq_cb(const struct device *dev, void *user_data);
+
+static int modem_uart_rx_prepare(void)
 {
+	if (!device_is_ready(modemUart)) {
+		return -ENODEV;
+	}
+
+	if (!modemUartRxIrqConfigured) {
+		ring_buf_init(&modemUartRxRing,
+			      sizeof(modemUartRxRingBuffer),
+			      modemUartRxRingBuffer);
+		uart_irq_callback_user_data_set(modemUart, modem_uart_rx_irq_cb, NULL);
+		modemUartRxIrqConfigured = true;
+	}
+
+	return 0;
+}
+
+static int modem_uart_rx_acquire(enum modem_uart_rx_owner owner)
+{
+	int ret = modem_uart_rx_prepare();
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
+		return -EBUSY;
+	}
+
+	modemUartRxOwner = owner;
+	ring_buf_reset(&modemUartRxRing);
+	uart_irq_rx_enable(modemUart);
+	return 0;
+}
+
+static void modem_uart_rx_release(enum modem_uart_rx_owner owner)
+{
+	if (modemUartRxOwner != owner) {
+		return;
+	}
+
+	uart_irq_rx_disable(modemUart);
+	ring_buf_reset(&modemUartRxRing);
+	modemUartRxOwner = MODEM_UART_RX_OWNER_NONE;
+}
+
+static uint32_t modem_uart_rx_read(void *ctx, uint8_t *buffer, size_t bufferSize)
+{
+	ARG_UNUSED(ctx);
+	return ring_buf_get(&modemUartRxRing, buffer, bufferSize);
+}
+
+static int modem_uart_irq_at_session_open(void *ctx, char *response, size_t responseSize)
+{
+	ARG_UNUSED(ctx);
+
+	if ((response == NULL) || (responseSize == 0U)) {
+		return -EINVAL;
+	}
+
+	int ret = modem_uart_rx_acquire(MODEM_UART_RX_OWNER_AT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	response[0] = '\0';
+	return 0;
+}
+
+static void modem_uart_irq_at_session_close(void *ctx)
+{
+	ARG_UNUSED(ctx);
+	modem_uart_rx_release(MODEM_UART_RX_OWNER_AT);
+}
+
+static void modem_at_debug_log_adapter(void *ctx, const char *fmt, ...)
+{
+	ARG_UNUSED(ctx);
+
 	if (modemAtDebugShell == NULL) {
 		return;
 	}
@@ -82,104 +168,20 @@ static void modem_at_debug_log(const char *fmt, ...)
 	shell_fprintf_normal(modemAtDebugShell, "%s\n", buffer);
 }
 
-static void modem_passthrough_uart_irq_cb(const struct device *dev, void *user_data);
-
-static int modem_uart_irq_prepare(void)
+static int modem_shell_at_send_irq(const char *command, char *response, size_t responseSize)
 {
-	if (!device_is_ready(modemUart)) {
-		return -ENODEV;
-	}
+	static const struct modem_at_irq_transport transport = {
+		.ctx = NULL,
+		.open = modem_uart_irq_at_session_open,
+		.close = modem_uart_irq_at_session_close,
+		.read = modem_uart_rx_read,
+	};
+	const struct modem_at_irq_debug debug = {
+		.ctx = NULL,
+		.log = modem_at_debug_log_adapter,
+	};
 
-	if (!passthroughIrqConfigured) {
-		ring_buf_init(&passthroughIrqRing,
-			      sizeof(passthroughIrqRingBuffer),
-			      passthroughIrqRingBuffer);
-		uart_irq_callback_user_data_set(modemUart, modem_passthrough_uart_irq_cb, NULL);
-		passthroughIrqConfigured = true;
-	}
-
-	return 0;
-}
-
-static int modem_at_send_irq(const char *command, char *response, size_t responseSize)
-{
-	modem_at_debug_log("[modem-at irq] enter cmd='%s'", command != NULL ? command : "<null>");
-
-	int ret = modem_uart_irq_prepare();
-	if (ret != 0) {
-		modem_at_debug_log("[modem-at irq] prepare failed ret=%d", ret);
-		return ret;
-	}
-
-	if ((command == NULL) || (response == NULL) || (responseSize == 0U)) {
-		modem_at_debug_log("[modem-at irq] invalid args");
-		return -EINVAL;
-	}
-
-	ring_buf_reset(&passthroughIrqRing);
-	response[0] = '\0';
-	modem_at_debug_log("[modem-at irq] ring reset");
-
-	uart_irq_rx_enable(modemUart);
-	modem_at_debug_log("[modem-at irq] rx irq enabled");
-
-	ret = modem_at_uart_write((const uint8_t *)command, strlen(command));
-	modem_at_debug_log("[modem-at irq] command write ret=%d len=%u", ret, (unsigned int)strlen(command));
-	if (ret == 0) {
-		static const uint8_t cr = '\r';
-		ret = modem_at_uart_write(&cr, 1U);
-		modem_at_debug_log("[modem-at irq] CR write ret=%d", ret);
-	}
-	if (ret != 0) {
-		uart_irq_rx_disable(modemUart);
-		modem_at_debug_log("[modem-at irq] write failed ret=%d", ret);
-		return ret;
-	}
-
-	size_t offset = 0U;
-	bool loggedFirstRx = false;
-	int64_t deadline = k_uptime_get() + 5000;
-	for (;;) {
-		uint8_t chunk[MODEM_PASSTHROUGH_RX_CHUNK_SIZE];
-		uint32_t received = ring_buf_get(&passthroughIrqRing, chunk, sizeof(chunk));
-		if (received > 0U) {
-			if (!loggedFirstRx) {
-				modem_at_debug_log("[modem-at irq] first rx chunk bytes=%u first=0x%02X", (unsigned int)received,
-						   (unsigned int)chunk[0]);
-				loggedFirstRx = true;
-			}
-			for (uint32_t i = 0; i < received; ++i) {
-				if (offset + 1U < responseSize) {
-					response[offset++] = (char)chunk[i];
-					response[offset] = '\0';
-				}
-			}
-
-			if ((strstr(response, "\r\nOK\r\n") != NULL) ||
-			    (strstr(response, "\nOK\r\n") != NULL) ||
-			    (strstr(response, "\nOK\n") != NULL)) {
-				uart_irq_rx_disable(modemUart);
-				modem_at_debug_log("[modem-at irq] success bytes=%u", (unsigned int)offset);
-				return 0;
-			}
-			if (strstr(response, "ERROR") != NULL) {
-				uart_irq_rx_disable(modemUart);
-				modem_at_debug_log("[modem-at irq] modem error bytes=%u", (unsigned int)offset);
-				return -EIO;
-			}
-
-			deadline = k_uptime_get() + 1000;
-			continue;
-		}
-
-		if (k_uptime_get() >= deadline) {
-			uart_irq_rx_disable(modemUart);
-			modem_at_debug_log("[modem-at irq] timeout bytes=%u", (unsigned int)offset);
-			return -ETIMEDOUT;
-		}
-
-		k_msleep(10);
-	}
+	return modem_at_send_irq(command, response, responseSize, &transport, &debug);
 }
 
 static const struct modem_shell_ops shellOps = {
@@ -189,8 +191,8 @@ static const struct modem_shell_ops shellOps = {
 	.modem_board_reset_pulse = modem_board_reset_pulse,
 	.modem_board_get_status = modem_board_get_status,
 	.modem_at_send = modem_at_send,
-	.modem_at_send_runtime = modem_at_send_irq,
-	.modem_at_send_power_on = modem_at_send_irq,
+	.modem_at_send_runtime = modem_shell_at_send_irq,
+	.modem_at_send_power_on = modem_shell_at_send_irq,
 	.sleep_ms = shell_sleep_ms_adapter,
 	.print = shell_print_adapter,
 	.error = shell_error_adapter,
@@ -204,13 +206,13 @@ static void modem_passthrough_stop(void)
 	}
 
 	passthroughActive = false;
-	uart_irq_rx_disable(modemUart);
+	modem_uart_rx_release(MODEM_UART_RX_OWNER_PASSTHROUGH);
 	shell_set_bypass(passthroughShell, NULL);
 	shell_print(passthroughShell, "\r\n[modem passthrough disabled]");
 	passthroughShell = NULL;
 	passthroughTail = 0U;
 	passthroughDebugMode = false;
-	ring_buf_reset(&passthroughIrqRing);
+	ring_buf_reset(&modemUartRxRing);
 }
 
 static void modem_passthrough_shell_write(const struct shell *sh, const char *data, size_t length)
@@ -276,7 +278,7 @@ static void modem_passthrough_print_text_chunk(const struct shell *sh, const uin
 	modem_passthrough_shell_write(sh, text, offset);
 }
 
-static void modem_passthrough_uart_irq_cb(const struct device *dev, void *user_data)
+static void modem_uart_rx_irq_cb(const struct device *dev, void *user_data)
 {
 	ARG_UNUSED(user_data);
 
@@ -290,7 +292,7 @@ static void modem_passthrough_uart_irq_cb(const struct device *dev, void *user_d
 			break;
 		}
 
-		(void)ring_buf_put(&passthroughIrqRing, buffer, (uint32_t)received);
+		(void)ring_buf_put(&modemUartRxRing, buffer, (uint32_t)received);
 	}
 }
 
@@ -307,7 +309,7 @@ static void modem_passthrough_rx_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 		uint8_t buffer[MODEM_PASSTHROUGH_RX_CHUNK_SIZE];
-		uint32_t length = ring_buf_get(&passthroughIrqRing, buffer, sizeof(buffer));
+		uint32_t length = ring_buf_get(&modemUartRxRing, buffer, sizeof(buffer));
 		if (length > 0U) {
 			if (passthroughDebugMode) {
 				modem_passthrough_trace_chunk(passthroughShell, buffer, length);
@@ -378,6 +380,13 @@ static int cmd_modem_reset(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_modem_power(const struct shell *sh, size_t argc, char **argv)
 {
+	if ((argc >= 2U) &&
+	    ((strcmp(argv[1], "on") == 0) || (strcmp(argv[1], "cycle") == 0)) &&
+	    (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE)) {
+		shell_error(sh, "modem UART RX is busy");
+		return -EBUSY;
+	}
+
 	struct modem_shell_ops ops = shellOps;
 	ops.ctx = (void *)sh;
 	return modem_shell_cmd_power_core(&ops, argc, argv);
@@ -385,6 +394,11 @@ static int cmd_modem_power(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_modem_at(const struct shell *sh, size_t argc, char **argv)
 {
+	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
+		shell_error(sh, "modem UART RX is busy");
+		return -EBUSY;
+	}
+
 	struct modem_shell_ops ops = shellOps;
 	ops.ctx = (void *)sh;
 	ops.modemAtDebug = (argc >= 2U) && (strcmp(argv[1], "--debug") == 0);
@@ -429,6 +443,11 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 		return -EBUSY;
 	}
 
+	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
+		shell_error(sh, "modem UART RX is busy");
+		return -EBUSY;
+	}
+
 	if (!passthroughThreadStarted) {
 		k_thread_create(&passthroughThread,
 				passthroughStack,
@@ -443,18 +462,16 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 		passthroughThreadStarted = true;
 	}
 
-	ret = modem_uart_irq_prepare();
+	ret = modem_uart_rx_acquire(MODEM_UART_RX_OWNER_PASSTHROUGH);
 	if (ret != 0) {
-		shell_error(sh, "failed to prepare modem UART IRQ RX: %d", ret);
+		shell_error(sh, "failed to acquire modem UART IRQ RX: %d", ret);
 		return ret;
 	}
 
-	ring_buf_reset(&passthroughIrqRing);
 	passthroughShell = sh;
 	passthroughTail = 0U;
 	passthroughDebugMode = debugMode;
 	passthroughActive = true;
-	uart_irq_rx_enable(modemUart);
 	shell_print(sh,
 		    debugMode ? "Entering modem UART passthrough (debug mode). Press Ctrl-X then Ctrl-Q to exit."
 		              : "Entering modem UART passthrough. Press Ctrl-X then Ctrl-Q to exit.");

--- a/platform/tests/catch2/CMakeLists.txt
+++ b/platform/tests/catch2/CMakeLists.txt
@@ -21,6 +21,15 @@ configure_catch2_test_target(platform_catch2_modem_board
     ${PLATFORM_SRC_DIR}/modem-board
 )
 
+configure_catch2_test_target(platform_catch2_modem_at
+  SOURCES
+    ${PLATFORM_SRC_DIR}/modem-at/modem-at.c
+    ${CMAKE_CURRENT_LIST_DIR}/modem-at/test_modem_at.cpp
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_LIST_DIR}/shims
+    ${PLATFORM_SRC_DIR}/modem-at/inc
+)
+
 configure_catch2_test_target(platform_catch2_modem_shell
   SOURCES
     ${PLATFORM_SRC_DIR}/modem-shell/modem-shell-core.c

--- a/platform/tests/catch2/modem-at/test_modem_at.cpp
+++ b/platform/tests/catch2/modem-at/test_modem_at.cpp
@@ -1,0 +1,252 @@
+#include <cstdarg>
+#include <deque>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+extern "C" {
+#include <zephyr/device.h>
+#include "modem-at.h"
+}
+
+namespace {
+
+struct FakeTransport {
+  int openRet = 0;
+  int openCalls = 0;
+  int closeCalls = 0;
+  std::deque<std::string> chunks;
+};
+
+struct FakeDebug {
+  std::vector<std::string> lines;
+};
+
+struct FakeUart {
+  bool ready = true;
+  int64_t nowMs = 0;
+  std::deque<int> pollIn;
+  std::string writes;
+  std::string pendingResponse;
+};
+
+FakeUart g_uart;
+
+int transport_open(void *ctx, char *response, size_t responseSize)
+{
+  auto *transport = static_cast<FakeTransport *>(ctx);
+  transport->openCalls++;
+  if ((response != nullptr) && (responseSize > 0U)) {
+    response[0] = '\0';
+  }
+  return transport->openRet;
+}
+
+void transport_close(void *ctx)
+{
+  auto *transport = static_cast<FakeTransport *>(ctx);
+  transport->closeCalls++;
+}
+
+uint32_t transport_read(void *ctx, uint8_t *buffer, size_t bufferSize)
+{
+  auto *transport = static_cast<FakeTransport *>(ctx);
+  if (transport->chunks.empty()) {
+    return 0;
+  }
+
+  std::string chunk = transport->chunks.front();
+  transport->chunks.pop_front();
+  const size_t copySize = std::min(bufferSize, chunk.size());
+  for (size_t i = 0; i < copySize; ++i) {
+    buffer[i] = static_cast<uint8_t>(chunk[i]);
+  }
+  return static_cast<uint32_t>(copySize);
+}
+
+void debug_log(void *ctx, const char *fmt, ...)
+{
+  auto *debug = static_cast<FakeDebug *>(ctx);
+  char buffer[256];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  debug->lines.emplace_back(buffer);
+}
+
+void reset_uart()
+{
+  g_uart = {};
+}
+
+} // namespace
+
+extern "C" {
+
+const struct device g_modem_at_test_device = {};
+
+bool device_is_ready(const struct device *dev)
+{
+  return (dev == &g_modem_at_test_device) && g_uart.ready;
+}
+
+int uart_poll_in(const struct device *dev, unsigned char *ch)
+{
+  if (dev != &g_modem_at_test_device) {
+    return -1;
+  }
+  if (g_uart.pollIn.empty()) {
+    return -1;
+  }
+
+  const int value = g_uart.pollIn.front();
+  g_uart.pollIn.pop_front();
+  if (value < 0) {
+    return value;
+  }
+
+  *ch = static_cast<unsigned char>(value);
+  return 0;
+}
+
+void uart_poll_out(const struct device *dev, unsigned char ch)
+{
+  if (dev == &g_modem_at_test_device) {
+    g_uart.writes.push_back(static_cast<char>(ch));
+    if ((ch == '\r') && !g_uart.pendingResponse.empty()) {
+      for (char pending : g_uart.pendingResponse) {
+        g_uart.pollIn.push_back(static_cast<unsigned char>(pending));
+      }
+      g_uart.pendingResponse.clear();
+    }
+  }
+}
+
+int64_t k_uptime_get(void)
+{
+  return g_uart.nowMs;
+}
+
+void k_msleep(int32_t ms)
+{
+  g_uart.nowMs += ms;
+}
+
+} // extern "C"
+
+TEST_CASE("modem_at_send_irq rejects invalid arguments", "[modem-at]")
+{
+  reset_uart();
+  char response[32] = {};
+  FakeTransport transport;
+
+  const modem_at_irq_transport transportOps = {
+    &transport,
+    transport_open,
+    transport_close,
+    transport_read,
+  };
+
+  REQUIRE(modem_at_send_irq(nullptr, response, sizeof(response), &transportOps, nullptr) == -EINVAL);
+  REQUIRE(modem_at_send_irq("AT", nullptr, sizeof(response), &transportOps, nullptr) == -EINVAL);
+  REQUIRE(modem_at_send_irq("AT", response, 0, &transportOps, nullptr) == -EINVAL);
+  REQUIRE(modem_at_send_irq("AT", response, sizeof(response), nullptr, nullptr) == -EINVAL);
+  REQUIRE(transport.openCalls == 0);
+}
+
+TEST_CASE("modem_at_send_irq writes command and returns response on OK", "[modem-at]")
+{
+  reset_uart();
+  FakeTransport transport;
+  transport.chunks.push_back("\r\nOK\r\n");
+  FakeDebug debug;
+  char response[32] = {};
+
+  const modem_at_irq_transport transportOps = {
+    &transport,
+    transport_open,
+    transport_close,
+    transport_read,
+  };
+  const modem_at_irq_debug debugOps = {
+    &debug,
+    debug_log,
+  };
+
+  REQUIRE(modem_at_send_irq("AT", response, sizeof(response), &transportOps, &debugOps) == 0);
+  REQUIRE(transport.openCalls == 1);
+  REQUIRE(transport.closeCalls == 1);
+  REQUIRE(g_uart.writes == std::string("AT\r"));
+  REQUIRE(std::string(response) == "\r\nOK\r\n");
+  REQUIRE_FALSE(debug.lines.empty());
+}
+
+TEST_CASE("modem_at_send_irq returns EIO on modem error text", "[modem-at]")
+{
+  reset_uart();
+  FakeTransport transport;
+  transport.chunks.push_back("\r\nERROR\r\n");
+  char response[32] = {};
+
+  const modem_at_irq_transport transportOps = {
+    &transport,
+    transport_open,
+    transport_close,
+    transport_read,
+  };
+
+  REQUIRE(modem_at_send_irq("AT", response, sizeof(response), &transportOps, nullptr) == -EIO);
+  REQUIRE(transport.openCalls == 1);
+  REQUIRE(transport.closeCalls == 1);
+  REQUIRE(std::string(response) == "\r\nERROR\r\n");
+}
+
+TEST_CASE("modem_at_send_irq times out and still closes transport", "[modem-at]")
+{
+  reset_uart();
+  FakeTransport transport;
+  char response[32] = {};
+
+  const modem_at_irq_transport transportOps = {
+    &transport,
+    transport_open,
+    transport_close,
+    transport_read,
+  };
+
+  REQUIRE(modem_at_send_irq("AT", response, sizeof(response), &transportOps, nullptr) == -ETIMEDOUT);
+  REQUIRE(transport.openCalls == 1);
+  REQUIRE(transport.closeCalls == 1);
+  REQUIRE(g_uart.nowMs >= 5000);
+}
+
+TEST_CASE("modem_at_send uses polling UART path and trims response", "[modem-at]")
+{
+  reset_uart();
+  g_uart.pendingResponse = "\r\nQuectel RC7620-1\r\nOK\r\n";
+
+  char response[64] = {};
+  REQUIRE(modem_at_send("ATI", response, sizeof(response)) == 0);
+  REQUIRE(g_uart.writes == std::string("ATI\r"));
+  REQUIRE(std::string(response) == "Quectel RC7620-1\nOK");
+
+  modem_at_diagnostics diagnostics = {};
+  modem_at_get_last_diagnostics(&diagnostics);
+  REQUIRE(diagnostics.sawAnyByte);
+  REQUIRE(diagnostics.exitReason == MODEM_AT_EXIT_MATCH_OK);
+}
+
+TEST_CASE("modem_at_send reports overall timeout when no bytes arrive", "[modem-at]")
+{
+  reset_uart();
+  char response[16] = {};
+
+  REQUIRE(modem_at_send("AT", response, sizeof(response)) == -ETIMEDOUT);
+
+  modem_at_diagnostics diagnostics = {};
+  modem_at_get_last_diagnostics(&diagnostics);
+  REQUIRE_FALSE(diagnostics.sawAnyByte);
+  REQUIRE(diagnostics.exitReason == MODEM_AT_EXIT_OVERALL_TIMEOUT);
+}

--- a/platform/tests/catch2/modem-at/test_modem_at.cpp
+++ b/platform/tests/catch2/modem-at/test_modem_at.cpp
@@ -225,12 +225,12 @@ TEST_CASE("modem_at_send_irq times out and still closes transport", "[modem-at]"
 TEST_CASE("modem_at_send uses polling UART path and trims response", "[modem-at]")
 {
   reset_uart();
-  g_uart.pendingResponse = "\r\nQuectel RC7620-1\r\nOK\r\n";
+  g_uart.pendingResponse = "\r\nSierra Wireless RC7620-1\r\nOK\r\n";
 
   char response[64] = {};
   REQUIRE(modem_at_send("ATI", response, sizeof(response)) == 0);
   REQUIRE(g_uart.writes == std::string("ATI\r"));
-  REQUIRE(std::string(response) == "Quectel RC7620-1\nOK");
+  REQUIRE(std::string(response) == "Sierra Wireless RC7620-1\nOK");
 
   modem_at_diagnostics diagnostics = {};
   modem_at_get_last_diagnostics(&diagnostics);

--- a/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
+++ b/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
@@ -207,6 +207,7 @@ TEST_CASE("modem status prints the current board state", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   REQUIRE(modem_shell_cmd_status_core(&ops) == 0);
@@ -233,6 +234,7 @@ TEST_CASE("modem status prints OFF when VGPIO is below threshold", "[modem-shell
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   REQUIRE(modem_shell_cmd_status_core(&ops) == 0);
@@ -259,6 +261,7 @@ TEST_CASE("modem status reports board read errors", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   REQUIRE(modem_shell_cmd_status_core(&ops) == -ENODEV);
@@ -285,6 +288,7 @@ TEST_CASE("modem status prints partial status when VGPIO read fails", "[modem-sh
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   REQUIRE(modem_shell_cmd_status_core(&ops) == 0);
@@ -310,6 +314,7 @@ TEST_CASE("modem reset prints OK on success", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   REQUIRE(modem_shell_cmd_reset_core(&ops) == 0);
@@ -336,6 +341,7 @@ TEST_CASE("modem power validates usage and dispatches requested operation", "[mo
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   modem_at_send_fake_fake.custom_fake = fake_at_send_power_on_success;
@@ -376,6 +382,7 @@ TEST_CASE("modem power reports unknown operations and downstream failures", "[mo
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "power";
@@ -413,6 +420,7 @@ TEST_CASE("modem power reports sleep-disable failures after successful power on"
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "power";
@@ -444,13 +452,14 @@ TEST_CASE("modem at validates usage", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
   char *argv[] = {command};
 
   REQUIRE(modem_shell_cmd_at_core(&ops, 1, argv) == -EINVAL);
-  REQUIRE(capture.lastError == "usage: at <command>");
+  REQUIRE(capture.lastError == "usage: at [--debug] <command>");
 }
 
 TEST_CASE("modem at refuses requests while modem rail is off", "[modem-shell]")
@@ -472,6 +481,7 @@ TEST_CASE("modem at refuses requests while modem rail is off", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
@@ -503,6 +513,7 @@ TEST_CASE("modem at prints transport response on success", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
@@ -512,7 +523,7 @@ TEST_CASE("modem at prints transport response on success", "[modem-shell]")
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
   REQUIRE(modem_at_send_fake_fake.call_count == 1);
   REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "ATI");
-  REQUIRE(capture.lastPrint == "[raw modem response]\nQuectel RC7620-1\n[modem-at] exit=inter-char-timeout bytes=16");
+  REQUIRE(capture.lastPrint == "Quectel RC7620-1");
   REQUIRE(capture.lastError.empty());
 }
 
@@ -536,6 +547,7 @@ TEST_CASE("modem at reports empty modem response explicitly", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
@@ -543,7 +555,7 @@ TEST_CASE("modem at reports empty modem response explicitly", "[modem-shell]")
   char *argv[] = {command, ati};
 
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
-  REQUIRE(capture.lastPrint == "[empty modem response]\n[modem-at] exit=matched-ok bytes=0");
+  REQUIRE(capture.lastPrint == "[empty modem response]");
   REQUIRE(capture.lastError.empty());
 }
 
@@ -567,6 +579,7 @@ TEST_CASE("modem at reports echo-only modem response explicitly", "[modem-shell]
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
@@ -574,7 +587,7 @@ TEST_CASE("modem at reports echo-only modem response explicitly", "[modem-shell]
   char *argv[] = {command, ati};
 
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
-  REQUIRE(capture.lastPrint == "[echo only]\nATI\n[modem-at] exit=inter-char-timeout bytes=3");
+  REQUIRE(capture.lastPrint == "ATI");
   REQUIRE(capture.lastError.empty());
 }
 
@@ -601,6 +614,7 @@ TEST_CASE("modem at reports transport errors cleanly", "[modem-shell]")
     shell_print_capture,
     shell_error_capture,
     &capture,
+    false,
   };
 
   char command[] = "at";
@@ -608,5 +622,73 @@ TEST_CASE("modem at reports transport errors cleanly", "[modem-shell]")
   char *argv[] = {command, csq};
 
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == -ETIMEDOUT);
-  // REQUIRE(capture.lastError == "AT command timed out waiting for modem response (exit=overall-timeout, bytes=0)");
+  REQUIRE(capture.lastError == "AT command timed out waiting for modem response");
+}
+
+TEST_CASE("modem at debug prints modem diagnostics on success", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_fake_fake.custom_fake = fake_at_send_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    true,
+  };
+
+  char command[] = "at";
+  char debug[] = "--debug";
+  char ati[] = "ATI";
+  char *argv[] = {command, debug, ati};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 3, argv) == 0);
+  REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "ATI");
+  REQUIRE(capture.lastPrint == "[raw modem response]\nQuectel RC7620-1\n[modem-at] exit=inter-char-timeout bytes=16");
+}
+
+TEST_CASE("modem at debug prints timeout diagnostics", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_fake_fake.return_val = -ETIMEDOUT;
+  g_lastDiagnostics.bytesReceived = 0;
+  g_lastDiagnostics.sawAnyByte = false;
+  g_lastDiagnostics.exitReason = MODEM_AT_EXIT_OVERALL_TIMEOUT;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    true,
+  };
+
+  char command[] = "at";
+  char debug[] = "--debug";
+  char csq[] = "AT+CSQ";
+  char *argv[] = {command, debug, csq};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 3, argv) == -ETIMEDOUT);
+  REQUIRE(capture.lastError == "AT command timed out waiting for modem response (exit=overall-timeout, bytes=0)");
 }

--- a/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
+++ b/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
@@ -108,7 +108,7 @@ int fake_status_unpowered(struct modem_board_status *out)
 int fake_at_send_success(const char *command, char *response, size_t responseSize)
 {
   (void)command;
-  snprintf(response, responseSize, "Quectel RC7620-1");
+  snprintf(response, responseSize, "Sierra Wireless RC7620-1");
   g_lastDiagnostics.bytesReceived = strlen(response);
   g_lastDiagnostics.sawAnyByte = true;
   g_lastDiagnostics.exitReason = MODEM_AT_EXIT_INTER_CHAR_TIMEOUT;
@@ -605,7 +605,7 @@ TEST_CASE("modem at prints transport response on success", "[modem-shell]")
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
   REQUIRE(modem_at_send_fake_fake.call_count == 1);
   REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "ATI");
-  REQUIRE(capture.lastPrint == "Quectel RC7620-1");
+  REQUIRE(capture.lastPrint == "Sierra Wireless RC7620-1");
   REQUIRE(capture.lastError.empty());
 }
 
@@ -674,7 +674,7 @@ TEST_CASE("modem at falls back to generic sender when runtime sender is absent",
   REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
   REQUIRE(modem_at_send_fake_fake.call_count == 1);
   REQUIRE(modem_at_send_power_on_fake_fake.call_count == 0);
-  REQUIRE(capture.lastPrint == "Quectel RC7620-1");
+  REQUIRE(capture.lastPrint == "Sierra Wireless RC7620-1");
 }
 
 TEST_CASE("modem at reports empty modem response explicitly", "[modem-shell]")
@@ -805,7 +805,7 @@ TEST_CASE("modem at debug prints modem diagnostics on success", "[modem-shell]")
 
   REQUIRE(modem_shell_cmd_at_core(&ops, 3, argv) == 0);
   REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "ATI");
-  REQUIRE(capture.lastPrint == "[raw modem response]\nQuectel RC7620-1\n[modem-at] exit=inter-char-timeout bytes=16");
+  REQUIRE(capture.lastPrint == "[raw modem response]\nSierra Wireless RC7620-1\n[modem-at] exit=inter-char-timeout bytes=24");
 }
 
 TEST_CASE("modem at debug prints timeout diagnostics", "[modem-shell]")

--- a/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
+++ b/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
@@ -17,6 +17,8 @@ FAKE_VALUE_FUNC0(int, modem_board_power_cycle_fake);
 FAKE_VALUE_FUNC0(int, modem_board_reset_pulse_fake);
 FAKE_VALUE_FUNC(int, modem_board_get_status_fake, struct modem_board_status *);
 FAKE_VALUE_FUNC3(int, modem_at_send_fake, const char *, char *, size_t);
+FAKE_VALUE_FUNC3(int, modem_at_send_runtime_fake, const char *, char *, size_t);
+FAKE_VALUE_FUNC3(int, modem_at_send_power_on_fake, const char *, char *, size_t);
 FAKE_VOID_FUNC1(modem_sleep_ms_fake, int32_t);
 
 namespace {
@@ -58,6 +60,8 @@ void reset_fakes()
   RESET_FAKE(modem_board_reset_pulse_fake);
   RESET_FAKE(modem_board_get_status_fake);
   RESET_FAKE(modem_at_send_fake);
+  RESET_FAKE(modem_at_send_runtime_fake);
+  RESET_FAKE(modem_at_send_power_on_fake);
   RESET_FAKE(modem_sleep_ms_fake);
   FFF_RESET_HISTORY();
   g_lastDiagnostics = {};
@@ -154,6 +158,18 @@ int fake_at_send_power_on_ksleep_fail(const char *command, char *response, size_
     return -ETIMEDOUT;
   }
   return -EINVAL;
+}
+
+int fake_at_send_runtime_success(const char *command, char *response, size_t responseSize)
+{
+  snprintf(response, responseSize, "runtime:%s", command);
+  return 0;
+}
+
+int fake_at_send_power_on_route_success(const char *command, char *response, size_t responseSize)
+{
+  snprintf(response, responseSize, "power-on:%s", command);
+  return 0;
 }
 
 
@@ -434,6 +450,72 @@ TEST_CASE("modem power reports sleep-disable failures after successful power on"
   REQUIRE(capture.lastError == "failed to disable modem sleep: -110");
 }
 
+TEST_CASE("modem power prefers dedicated power-on sender when configured", "[modem-shell]")
+{
+  reset_fakes();
+  modem_at_send_power_on_fake_fake.custom_fake = fake_at_send_power_on_route_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_runtime_fake,
+    modem_at_send_power_on_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "power";
+  char on[] = "on";
+  char *argv[] = {command, on};
+
+  REQUIRE(modem_shell_cmd_power_core(&ops, 2, argv) == 0);
+  REQUIRE(modem_at_send_power_on_fake_fake.call_count == 2);
+  REQUIRE(modem_at_send_runtime_fake_fake.call_count == 0);
+  REQUIRE(modem_at_send_fake_fake.call_count == 0);
+  REQUIRE(std::string(modem_at_send_power_on_fake_fake.arg0_history[0]) == "AT");
+  REQUIRE(std::string(modem_at_send_power_on_fake_fake.arg0_history[1]) == "AT+KSLEEP=2");
+  REQUIRE(capture.lastPrint == "OK");
+}
+
+TEST_CASE("modem power falls back to runtime sender before generic sender", "[modem-shell]")
+{
+  reset_fakes();
+  modem_at_send_runtime_fake_fake.custom_fake = fake_at_send_power_on_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_runtime_fake,
+    nullptr,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "power";
+  char on[] = "on";
+  char *argv[] = {command, on};
+
+  REQUIRE(modem_shell_cmd_power_core(&ops, 2, argv) == 0);
+  REQUIRE(modem_at_send_runtime_fake_fake.call_count == 2);
+  REQUIRE(modem_at_send_fake_fake.call_count == 0);
+}
+
 TEST_CASE("modem at validates usage", "[modem-shell]")
 {
   reset_fakes();
@@ -525,6 +607,74 @@ TEST_CASE("modem at prints transport response on success", "[modem-shell]")
   REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "ATI");
   REQUIRE(capture.lastPrint == "Quectel RC7620-1");
   REQUIRE(capture.lastError.empty());
+}
+
+TEST_CASE("modem at prefers runtime sender when configured", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_runtime_fake_fake.custom_fake = fake_at_send_runtime_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_runtime_fake,
+    modem_at_send_power_on_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "at";
+  char ati[] = "ATI";
+  char *argv[] = {command, ati};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
+  REQUIRE(modem_at_send_runtime_fake_fake.call_count == 1);
+  REQUIRE(modem_at_send_fake_fake.call_count == 0);
+  REQUIRE(modem_at_send_power_on_fake_fake.call_count == 0);
+  REQUIRE(std::string(modem_at_send_runtime_fake_fake.arg0_val) == "ATI");
+  REQUIRE(capture.lastPrint == "runtime:ATI");
+}
+
+TEST_CASE("modem at falls back to generic sender when runtime sender is absent", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_fake_fake.custom_fake = fake_at_send_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    nullptr,
+    modem_at_send_power_on_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "at";
+  char ati[] = "ATI";
+  char *argv[] = {command, ati};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
+  REQUIRE(modem_at_send_fake_fake.call_count == 1);
+  REQUIRE(modem_at_send_power_on_fake_fake.call_count == 0);
+  REQUIRE(capture.lastPrint == "Quectel RC7620-1");
 }
 
 TEST_CASE("modem at reports empty modem response explicitly", "[modem-shell]")

--- a/platform/tests/catch2/shims/zephyr/device.h
+++ b/platform/tests/catch2/shims/zephyr/device.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct device {
+  int unused;
+};
+
+extern const struct device g_modem_at_test_device;
+
+bool device_is_ready(const struct device *dev);
+
+#define DT_NODELABEL(name) 0
+#define DEVICE_DT_GET(node_id) (&g_modem_at_test_device)
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/tests/catch2/shims/zephyr/drivers/uart.h
+++ b/platform/tests/catch2/shims/zephyr/drivers/uart.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int uart_poll_in(const struct device *dev, unsigned char *ch);
+void uart_poll_out(const struct device *dev, unsigned char ch);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/tests/catch2/shims/zephyr/kernel.h
+++ b/platform/tests/catch2/shims/zephyr/kernel.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int64_t k_uptime_get(void);
+void k_msleep(int32_t ms);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- clean up modem debug UX so verbose AT tracing is opt-in via `--debug`
- rename passthrough trace mode from `--hex` to `--debug`
- stabilize modem-shell timeout/error handling and tests
- make modem UART RX ownership explicit and exclusive across AT vs passthrough modes
- move the IRQ-based AT transaction engine into `platform/src/modem-at`
- centralize AT sender selection in shell core and add focused routing/fallback tests

## Key changes
- `modem at --debug <cmd>` now enables detailed IRQ/response diagnostics; normal `modem at <cmd>` stays clean
- shared modem UART RX infrastructure in `modem-shell.c` now has explicit ownership and neutral naming
- AT-specific IRQ transport logic now lives in `modem-at`, while shell keeps RX ownership + passthrough UX
- shell-core runtime/power-on sender selection now goes through one shared chooser/runner
- Catch2 coverage now explicitly checks sender preference/fallback behavior

## Validation
- `cmake --build platform/tests/catch2/build`
- `ctest --test-dir platform/tests/catch2/build --output-on-failure`
- `west build control -p auto -b control@a4 --shield sense_a3 -d control/build`

## Notes
- This branch includes the earlier cleanup commit plus the Phase D RX ownership / IRQ transport refactor.
