### PR TITLE
Fix AT query shell parsing

### DIFF
--- a/platform/src/modem-shell/modem-shell-core.c
+++ b/platform/src/modem-shell/modem-shell-core.c
@@ -1,5 +1,6 @@
 #include "modem-shell-core.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <string.h>
 
@@ -45,6 +46,75 @@ static int modem_shell_run_at_command(const struct modem_shell_ops *ops,
 	}
 
 	return send_fn(command, response, responseSize);
+}
+
+static char *modem_shell_trim_leading_spaces(char *text)
+{
+	while ((*text != '\0') && isspace((unsigned char)*text)) {
+		text++;
+	}
+
+	return text;
+}
+
+static char *modem_shell_trim_matching_quotes(char *text)
+{
+	size_t len = strlen(text);
+
+	if (len < 2U) {
+		return text;
+	}
+
+	if (((text[0] == '"') && (text[len - 1U] == '"')) ||
+	    ((text[0] == '\'') && (text[len - 1U] == '\''))) {
+		text[len - 1U] = '\0';
+		return text + 1;
+	}
+
+	return text;
+}
+
+static char *modem_shell_parse_at_command(size_t argc, char **argv, bool *debugEnabled)
+{
+	char *command;
+
+	*debugEnabled = false;
+
+	if (argc <= 1U) {
+		return NULL;
+	}
+
+	if ((argc >= 2U) && (strcmp(argv[1], "--debug") == 0)) {
+		*debugEnabled = true;
+		if (argc <= 2U) {
+			return NULL;
+		}
+
+		return argv[2];
+	}
+
+	if (argc > 2U) {
+		return argv[1];
+	}
+
+	command = modem_shell_trim_leading_spaces(argv[1]);
+	if (strncmp(command, "--debug", strlen("--debug")) == 0) {
+		char next = command[strlen("--debug")];
+
+		if ((next == '\0') || isspace((unsigned char)next)) {
+			*debugEnabled = true;
+			command = modem_shell_trim_leading_spaces(command + strlen("--debug"));
+		}
+	}
+
+	if (*command == '\0') {
+		return NULL;
+	}
+
+	command = modem_shell_trim_matching_quotes(command);
+	command = modem_shell_trim_leading_spaces(command);
+
+	return (*command == '\0') ? NULL : command;
 }
 
 static int modem_shell_disable_sleep_after_power_on(const struct modem_shell_ops *ops)
@@ -166,20 +236,17 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 	struct modem_board_status st;
 	struct modem_at_diagnostics diagnostics = {0};
 	char response[256] = {0};
+	bool debugRequested = false;
+	bool debugOutputEnabled;
 	const char *command;
-	size_t commandIndex = 1U;
 	int ret;
 
-	if ((argc >= 2U) && (strcmp(argv[1], "--debug") == 0)) {
-		commandIndex = 2U;
-	}
-
-	if (argc <= commandIndex) {
+	command = modem_shell_parse_at_command(argc, argv, &debugRequested);
+	debugOutputEnabled = ops->modemAtDebug || debugRequested;
+	if (command == NULL) {
 		ops->error(ops->ctx, "usage: at [--debug] <command>");
 		return -EINVAL;
 	}
-
-	command = argv[commandIndex];
 
 	ret = ops->modem_board_get_status(&st);
 	if (ret != 0) {
@@ -199,7 +266,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 					 sizeof(response));
 	modem_at_get_last_diagnostics(&diagnostics);
 	if (ret != 0) {
-		if (ops->modemAtDebug && (response[0] != '\0')) {
+		if (debugOutputEnabled && (response[0] != '\0')) {
 			ops->error(ops->ctx,
 				"[raw modem response on error]\n%s\n[modem-at] exit=%s bytes=%u ret=%d",
 				response,
@@ -207,7 +274,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 				(unsigned int)diagnostics.bytesReceived,
 				ret);
 		} else if (ret == -ETIMEDOUT) {
-			if (ops->modemAtDebug) {
+			if (debugOutputEnabled) {
 				ops->error(ops->ctx,
 					"AT command timed out waiting for modem response (exit=%s, bytes=%u)",
 					modem_at_exit_reason_str(diagnostics.exitReason),
@@ -215,7 +282,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 			} else {
 				ops->error(ops->ctx, "AT command timed out waiting for modem response");
 			}
-		} else if (ops->modemAtDebug) {
+		} else if (debugOutputEnabled) {
 			ops->error(ops->ctx,
 				"AT command failed: %d (exit=%s, bytes=%u)",
 				ret,
@@ -228,7 +295,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 	}
 
 	if (response[0] == '\0') {
-		if (ops->modemAtDebug) {
+		if (debugOutputEnabled) {
 			ops->print(ops->ctx,
 				"[empty modem response]\n[modem-at] exit=%s bytes=%u",
 				modem_at_exit_reason_str(diagnostics.exitReason),
@@ -239,7 +306,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 		return 0;
 	}
 
-	if (ops->modemAtDebug && (strcmp(response, command) == 0)) {
+	if (debugOutputEnabled && (strcmp(response, command) == 0)) {
 		ops->print(ops->ctx,
 			"[echo only]\n%s\n[modem-at] exit=%s bytes=%u",
 			response,
@@ -248,7 +315,7 @@ int modem_shell_cmd_at_core(const struct modem_shell_ops *ops, size_t argc, char
 		return 0;
 	}
 
-	if (ops->modemAtDebug) {
+	if (debugOutputEnabled) {
 		ops->print(ops->ctx,
 			"[raw modem response]\n%s\n[modem-at] exit=%s bytes=%u",
 			response,

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -3,6 +3,7 @@
 #include "modem-at.h"
 #include "modem-board.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -166,6 +167,35 @@ static void modem_at_debug_log_adapter(void *ctx, const char *fmt, ...)
 	va_end(args);
 
 	shell_fprintf_normal(modemAtDebugShell, "%s\n", buffer);
+}
+
+static bool modem_shell_at_debug_requested(size_t argc, char **argv)
+{
+	char *raw;
+
+	if (argc <= 1U) {
+		return false;
+	}
+
+	if (strcmp(argv[1], "--debug") == 0) {
+		return true;
+	}
+
+	if (argc != 2U) {
+		return false;
+	}
+
+	raw = argv[1];
+	while ((*raw != '\0') && isspace((unsigned char)*raw)) {
+		raw++;
+	}
+
+	if (strncmp(raw, "--debug", strlen("--debug")) != 0) {
+		return false;
+	}
+
+	return (raw[strlen("--debug")] == '\0') ||
+	       isspace((unsigned char)raw[strlen("--debug")]);
 }
 
 static int modem_shell_at_send_irq(const char *command, char *response, size_t responseSize)
@@ -401,7 +431,7 @@ static int cmd_modem_at(const struct shell *sh, size_t argc, char **argv)
 
 	struct modem_shell_ops ops = shellOps;
 	ops.ctx = (void *)sh;
-	ops.modemAtDebug = (argc >= 2U) && (strcmp(argv[1], "--debug") == 0);
+	ops.modemAtDebug = modem_shell_at_debug_requested(argc, argv);
 	modemAtDebugShell = ops.modemAtDebug ? sh : NULL;
 	int ret = modem_shell_cmd_at_core(&ops, argc, argv);
 	modemAtDebugShell = NULL;
@@ -483,7 +513,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD(status, NULL, "Print modem GPIO status", cmd_modem_status),
 	SHELL_CMD(reset, NULL, "Pulse modem reset (MODEM_nRST)", cmd_modem_reset),
 	SHELL_CMD_ARG(power, NULL, "Modem power control: power <on|off|cycle>", cmd_modem_power, 2, 0),
-	SHELL_CMD_ARG(at, NULL, "Send AT command: at [--debug] <command>", cmd_modem_at, 2, 1),
+	SHELL_CMD_ARG(at, NULL, "Send AT command: at [--debug] <command>", cmd_modem_at, 2, SHELL_OPT_ARG_RAW),
 	SHELL_CMD_ARG(passthrough, NULL,
 		      "Raw UART passthrough to modem. Use --debug for RX trace mode; Ctrl-X then Ctrl-Q exits.",
 		      cmd_modem_passthrough, 1, 1),

--- a/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
+++ b/platform/tests/catch2/modem-shell/test_modem_shell_core.cpp
@@ -609,6 +609,70 @@ TEST_CASE("modem at prints transport response on success", "[modem-shell]")
   REQUIRE(capture.lastError.empty());
 }
 
+TEST_CASE("modem at accepts quoted raw query commands", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_fake_fake.custom_fake = fake_at_send_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "at";
+  char query[] = "\"AT+COPS?\"";
+  char *argv[] = {command, query};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
+  REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "AT+COPS?");
+  REQUIRE(capture.lastPrint == "Sierra Wireless RC7620-1");
+}
+
+TEST_CASE("modem at accepts raw debug-prefixed query commands", "[modem-shell]")
+{
+  reset_fakes();
+  modem_board_get_status_fake_fake.custom_fake = fake_status_success;
+  modem_at_send_fake_fake.custom_fake = fake_at_send_success;
+  ShellCapture capture;
+
+  modem_shell_ops ops = {
+    modem_board_power_on_fake,
+    modem_board_power_off_fake,
+    modem_board_power_cycle_fake,
+    modem_board_reset_pulse_fake,
+    modem_board_get_status_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_at_send_fake,
+    modem_sleep_ms_fake,
+    shell_print_capture,
+    shell_error_capture,
+    &capture,
+    false,
+  };
+
+  char command[] = "at";
+  char query[] = "--debug \"AT!UIMS?\"";
+  char *argv[] = {command, query};
+
+  REQUIRE(modem_shell_cmd_at_core(&ops, 2, argv) == 0);
+  REQUIRE(std::string(modem_at_send_fake_fake.arg0_val) == "AT!UIMS?");
+  REQUIRE(capture.lastPrint == "[raw modem response]\nSierra Wireless RC7620-1\n[modem-at] exit=inter-char-timeout bytes=24");
+}
+
 TEST_CASE("modem at prefers runtime sender when configured", "[modem-shell]")
 {
   reset_fakes();


### PR DESCRIPTION
## Summary
- fix `modem at` so AT commands containing `?` are not broken by Zephyr shell wildcard parsing
- register the shell command to accept the AT payload as a raw argument
- preserve `--debug` support when passed in raw form
- add regression tests for quoted/raw AT query commands like `AT+COPS?` and `AT!UIMS?`

Fixes #31.

## Root cause
Zephyr shell wildcard support treats `?` as a wildcard character in parsed arguments. Our `modem at` command was registered as a normal parsed command, so query commands like `AT+COPS?` were intercepted by shell parsing before they ever reached the modem AT handler.

## Validation
- `cmake --build platform/tests/catch2/build`
- `ctest --test-dir platform/tests/catch2/build --output-on-failure`
- `. /home/node/.openclaw/workspace/tools/zephyr-venv/bin/activate && west build control -p auto -b control@a4 --shield sense_a3 -d control/build`
