### PR TITLE
Iteration 3: PPP link bring-up (Zephyr owns IP)

### DIFF
--- a/control/CMakeLists.txt
+++ b/control/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(app PRIVATE
 target_link_libraries(app PRIVATE platform_src_modem_board_obj)
 target_link_libraries(app PRIVATE platform_src_modem_at_obj)
 target_link_libraries(app PRIVATE platform_src_modem_shell_obj)
+target_link_libraries(app PRIVATE platform_src_modem_net_obj)
 
 mark_zephyr_system_includes(app)
 target_link_libraries(app PRIVATE zephyr_interface)

--- a/control/prj.conf
+++ b/control/prj.conf
@@ -97,6 +97,12 @@ CONFIG_NET_LOG=y
 CONFIG_NET_L2_PPP_LOG_LEVEL_DBG=y
 CONFIG_NET_L2_PPP_OPTION_DNS_USE=n
 
+CONFIG_NET_SHELL=y
+CONFIG_NET_SOCKETS=y
+
+CONFIG_NET_TCP=y
+CONFIG_NET_UDP=y
+
 ### / Temp for Devboard to P2 board bringup ###
 
 ####  RTOS Configuration ###

--- a/control/prj.conf
+++ b/control/prj.conf
@@ -63,6 +63,22 @@ CONFIG_USB_DEVICE_PRODUCT="Modem Control Shell"
 CONFIG_USB_CDC_ACM_RINGBUF_SIZE=2048
 # Keep the system workqueue responsive during USB IO
 CONFIG_SYSTEM_WORKQUEUE_PRIORITY=5
+
+# Modem / PPP networking
+CONFIG_NETWORKING=y
+CONFIG_NET_NATIVE=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_MGMT=y
+CONFIG_NET_MGMT_EVENT=y
+CONFIG_NET_L2_PPP=y
+CONFIG_NET_L2_PPP_OPTION_DNS_USE=y
+CONFIG_NET_L2_PPP_MGMT=y
+CONFIG_DNS_RESOLVER=y
+CONFIG_MODEM_MODULES=y
+CONFIG_MODEM_PPP=y
+CONFIG_MODEM_BACKEND_UART=y
+CONFIG_MODEM_BACKEND_UART_ISR=y
+CONFIG_MODEM_BACKEND_UART_ASYNC=n
 ### / Temp for Devboard to P2 board bringup ###
 
 ####  RTOS Configuration ###
@@ -75,8 +91,8 @@ CONFIG_THREAD_RUNTIME_STATS=y           # Gather thread runtime statistics. For 
 CONFIG_SCHED_THREAD_USAGE=y             # Collect thread runtime usage. Used for monitoring of scheduler performance
 CONFIG_INIT_STACKS=y                    # Initialise stacks with a known value so that high water mark can be determined for debugging
                                         # Init value: 0xAA
-CONFIG_NUM_COOP_PRIORITIES=0
-                                        # Default: 16, we do not use coop task now. Need to open if needed.
+CONFIG_NUM_COOP_PRIORITIES=1
+                                        # Networking/PPP traffic classes require at least one cooperative priority.
 CONFIG_PRIORITY_CEILING=0
                                         # If cooperative task is disabled, ceiling priority should be 0, not -127(default)
 

--- a/control/prj.conf
+++ b/control/prj.conf
@@ -41,7 +41,7 @@ CONFIG_SHELL=y
 CONFIG_SHELL_BACKEND_SERIAL=y
 CONFIG_SHELL_LOG_BACKEND=n              # Needed to prevent logs from being sent to the shell backend
 CONFIG_KERNEL_SHELL=y
-CONFIG_SHELL_STACK_SIZE=4096
+CONFIG_SHELL_STACK_SIZE=8192
 
 # USB device stack / CDC ACM
 CONFIG_USB_DEVICE_STACK=y
@@ -79,10 +79,28 @@ CONFIG_MODEM_PPP=y
 CONFIG_MODEM_BACKEND_UART=y
 CONFIG_MODEM_BACKEND_UART_ISR=y
 CONFIG_MODEM_BACKEND_UART_ASYNC=n
+
+CONFIG_LOG_MODE_IMMEDIATE=y
+CONFIG_NET_LOG=y
+CONFIG_NET_L2_PPP_LOG_LEVEL_DBG=y
+CONFIG_NET_PPP_LOG_LEVEL_DBG=y
+CONFIG_NET_TX_STACK_SIZE=4096
+CONFIG_NET_RX_STACK_SIZE=4096
+
+CONFIG_NETWORKING=y
+CONFIG_NET_L2_PPP=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_IPV6=n
+CONFIG_NET_L2_PPP_PAP=y
+CONFIG_LOG=y
+CONFIG_NET_LOG=y
+CONFIG_NET_L2_PPP_LOG_LEVEL_DBG=y
+CONFIG_NET_L2_PPP_OPTION_DNS_USE=n
+
 ### / Temp for Devboard to P2 board bringup ###
 
 ####  RTOS Configuration ###
-CONFIG_MAIN_STACK_SIZE=3072
+CONFIG_MAIN_STACK_SIZE=8192
                                         # Keeping main stack size to be 2K to allow sufficient stack space for inits to happen
 CONFIG_THREAD_NAME=y                    # Allow tracing to display thread name for debugging
 CONFIG_THREAD_STACK_INFO=y              # Allow each thread to store thread stack info in k_thread data structure
@@ -181,7 +199,7 @@ CONFIG_ASSERT_LEVEL=2
                                             # Enable asserts but don't warn on files that include __assert.h
 CONFIG_LOG_BACKEND_SHOW_COLOR=n             # Disable colour support to avoid special characters appearing in smarttalk bogs
 CONFIG_LOG_MODE_OVERFLOW=y                  # Drop the old messages if there is no space left for a new log message
-CONFIG_LOG_DEFAULT_LEVEL=4
+CONFIG_LOG_DEFAULT_LEVEL=3
                                             # Set the default log level to DEBUG
 
 #### Extras

--- a/platform/CMakeFiles/build-platform-targets.cmake
+++ b/platform/CMakeFiles/build-platform-targets.cmake
@@ -1,3 +1,4 @@
 add_subdirectory(${PLATFORM_SRC_DIR}/modem-at ${CMAKE_CURRENT_BINARY_DIR}/platform/src/modem-at EXCLUDE_FROM_ALL)
 add_subdirectory(${PLATFORM_SRC_DIR}/modem-board ${CMAKE_CURRENT_BINARY_DIR}/platform/src/modem-board EXCLUDE_FROM_ALL)
 add_subdirectory(${PLATFORM_SRC_DIR}/modem-shell ${CMAKE_CURRENT_BINARY_DIR}/platform/src/modem-shell EXCLUDE_FROM_ALL)
+add_subdirectory(${PLATFORM_SRC_DIR}/modem-net ${CMAKE_CURRENT_BINARY_DIR}/platform/src/modem-net EXCLUDE_FROM_ALL)

--- a/platform/src/modem-net/CMakeLists.txt
+++ b/platform/src/modem-net/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(LIBRARY_NAME platform_src_modem_net)
+
+add_library(${LIBRARY_NAME} INTERFACE)
+
+target_link_libraries(${LIBRARY_NAME} INTERFACE zephyr_interface)
+
+set(LIBRARY_NAME_OBJ platform_src_modem_net_obj)
+
+add_library(${LIBRARY_NAME_OBJ} OBJECT)
+
+target_include_directories(${LIBRARY_NAME_OBJ} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${PLATFORM_SRC_DIR}/modem-at/inc
+  ${PLATFORM_SRC_DIR}/modem-board/inc
+  ${PLATFORM_SRC_DIR}/modem-shell
+)
+
+target_sources(${LIBRARY_NAME_OBJ} PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/modem-net-core.c
+  ${CMAKE_CURRENT_LIST_DIR}/modem-net.c
+)
+
+target_link_libraries(${LIBRARY_NAME_OBJ} PUBLIC
+  platform_src_modem_net
+  platform_src_modem_at
+  platform_src_modem_board
+)
+
+mark_zephyr_system_includes(${LIBRARY_NAME_OBJ})
+add_dependencies(${LIBRARY_NAME_OBJ} zephyr_generated_headers)

--- a/platform/src/modem-net/modem-net-core.c
+++ b/platform/src/modem-net/modem-net-core.c
@@ -108,6 +108,9 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 	return 0;
 
 out_close:
+	if ((failedStage != NULL) && (strcmp(failedStage, "wait_for_network") == 0)) {
+		ops->print(ops->ctx, "PPP network wait timed out, tearing down session...");
+	}
 	(void)ops->escape_and_hangup();
 	ops->close_uart_session();
 out_fail:

--- a/platform/src/modem-net/modem-net-core.c
+++ b/platform/src/modem-net/modem-net-core.c
@@ -1,0 +1,176 @@
+#include "modem-net-core.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#define MODEM_UART_OWNER_NONE 0
+#define MODEM_UART_OWNER_AT 1
+#define MODEM_UART_OWNER_PASSTHROUGH 2
+#define MODEM_UART_OWNER_PPP 3
+
+static const char *modem_net_owner_name(int owner)
+{
+	switch (owner) {
+	case MODEM_UART_OWNER_AT:
+		return "at";
+	case MODEM_UART_OWNER_PASSTHROUGH:
+		return "passthrough";
+	case MODEM_UART_OWNER_PPP:
+		return "ppp";
+	default:
+		return "none";
+	}
+}
+
+int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, char **argv)
+{
+	const char *apn;
+	int ret;
+
+	if ((ops == NULL) || (ops->owner_get == NULL) || (ops->ensure_powered == NULL) ||
+	    (ops->configure_context == NULL) || (ops->open_uart_session == NULL) ||
+	    (ops->dial_ppp == NULL) || (ops->attach_ppp == NULL) ||
+	    (ops->wait_for_network == NULL) || (ops->close_uart_session == NULL) ||
+	    (ops->escape_and_hangup == NULL) || (ops->set_apn == NULL) ||
+	    (ops->set_error == NULL) || (ops->clear_error == NULL) ||
+	    (ops->print == NULL) || (ops->error == NULL)) {
+		return -EINVAL;
+	}
+
+	ops->clear_error();
+
+	if (argc < 2U) {
+		ops->error(ops->ctx, "usage: net connect <apn>");
+		ops->set_error(-EINVAL, "APN required");
+		return -EINVAL;
+	}
+
+	apn = argv[1];
+	if ((apn == NULL) || (apn[0] == '\0')) {
+		ops->error(ops->ctx, "usage: net connect <apn>");
+		ops->set_error(-EINVAL, "APN required");
+		return -EINVAL;
+	}
+
+	if (ops->owner_get() != MODEM_UART_OWNER_NONE) {
+		ops->error(ops->ctx, "modem UART is busy");
+		ops->set_error(-EBUSY, "modem UART busy");
+		return -EBUSY;
+	}
+
+	ops->set_apn(apn);
+
+	ret = ops->ensure_powered(ops->ctx);
+	if (ret != 0) {
+		goto out_fail;
+	}
+
+	ret = ops->configure_context(ops->ctx, apn);
+	if (ret != 0) {
+		goto out_fail;
+	}
+
+	ret = ops->open_uart_session();
+	if (ret != 0) {
+		goto out_fail;
+	}
+
+	ret = ops->dial_ppp(ops->ctx);
+	if (ret != 0) {
+		goto out_close;
+	}
+
+	ret = ops->attach_ppp();
+	if (ret != 0) {
+		goto out_close;
+	}
+
+	ret = ops->wait_for_network(ops->ctx);
+	if (ret != 0) {
+		goto out_close;
+	}
+
+	ops->print(ops->ctx, "PPP connected");
+	return 0;
+
+out_close:
+	(void)ops->escape_and_hangup();
+	ops->close_uart_session();
+out_fail:
+	ops->set_error(ret, "connect failed");
+	ops->error(ops->ctx, "connect failed: %d", ret);
+	return ret;
+}
+
+int modem_net_cmd_disconnect_core(const struct modem_net_ops *ops, size_t argc, char **argv)
+{
+	struct modem_net_status status = {0};
+	int ret;
+
+	(void)argc;
+	(void)argv;
+
+	if ((ops == NULL) || (ops->get_status == NULL) || (ops->print == NULL) ||
+	    (ops->escape_and_hangup == NULL) || (ops->close_uart_session == NULL)) {
+		return -EINVAL;
+	}
+
+	ret = ops->get_status(&status);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (!status.sessionOpen) {
+		ops->print(ops->ctx, "PPP already disconnected");
+		return 0;
+	}
+
+	ops->print(ops->ctx, "Disconnecting PPP...");
+	(void)ops->escape_and_hangup();
+	ops->close_uart_session();
+	ops->print(ops->ctx, "PPP disconnected");
+	return 0;
+}
+
+int modem_net_cmd_status_core(const struct modem_net_ops *ops, size_t argc, char **argv)
+{
+	struct modem_net_status status = {0};
+	const char *pppState;
+	int ret;
+
+	(void)argc;
+	(void)argv;
+
+	if ((ops == NULL) || (ops->get_status == NULL) || (ops->print == NULL) ||
+	    (ops->error == NULL)) {
+		return -EINVAL;
+	}
+
+	ret = ops->get_status(&status);
+	if (ret != 0) {
+		ops->error(ops->ctx, "status read failed: %d", ret);
+		return ret;
+	}
+
+	if (status.connected) {
+		pppState = "connected";
+	} else if (status.sessionOpen) {
+		pppState = "session-open";
+	} else {
+		pppState = "down";
+	}
+
+	ops->print(ops->ctx,
+		   "modem=%s owner=%s ppp=%s ip=%s dns=%s apn=%s last_error=%d%s%s",
+		   status.modemPowered ? "on" : "off",
+		   modem_net_owner_name(status.uartOwner),
+		   pppState,
+		   ((status.ipv4 != NULL) && (status.ipv4[0] != '\0')) ? status.ipv4 : "-",
+		   status.dnsReady ? "ready" : "pending",
+		   ((status.apn != NULL) && (status.apn[0] != '\0')) ? status.apn : "-",
+		   status.lastError,
+		   ((status.lastErrorText != NULL) && (status.lastErrorText[0] != '\0')) ? " " : "",
+		   ((status.lastErrorText != NULL) && (status.lastErrorText[0] != '\0')) ? status.lastErrorText : "");
+	return 0;
+}

--- a/platform/src/modem-net/modem-net-core.c
+++ b/platform/src/modem-net/modem-net-core.c
@@ -41,14 +41,14 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 	ops->clear_error();
 
 	if (argc < 2U) {
-		ops->error(ops->ctx, "usage: net connect <apn>");
+		ops->error(ops->ctx, "usage: modem ppp connect <apn>");
 		ops->set_error(-EINVAL, "APN required");
 		return -EINVAL;
 	}
 
 	apn = argv[1];
 	if ((apn == NULL) || (apn[0] == '\0')) {
-		ops->error(ops->ctx, "usage: net connect <apn>");
+		ops->error(ops->ctx, "usage: modem ppp connect <apn>");
 		ops->set_error(-EINVAL, "APN required");
 		return -EINVAL;
 	}

--- a/platform/src/modem-net/modem-net-core.c
+++ b/platform/src/modem-net/modem-net-core.c
@@ -25,7 +25,6 @@ static const char *modem_net_owner_name(int owner)
 
 int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, char **argv)
 {
-	const char *apn;
 	const char *failedStage = NULL;
 	int ret;
 
@@ -41,14 +40,20 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 
 	ops->clear_error();
 
-	if (argc < 2U) {
-		ops->error(ops->ctx, "usage: modem ppp connect <apn>");
-		ops->set_error(-EINVAL, "APN required");
+
+	if (argc < 4U) {
+		ops->error(ops->ctx, "usage: modem ppp connect <apn> <id> <password>");
+		ops->set_error(-EINVAL, "APN/ID/PASS required");
 		return -EINVAL;
 	}
 
-	apn = argv[1];
-	if ((apn == NULL) || (apn[0] == '\0')) {
+	struct modem_net_profile prof = {
+		.apn = argv[1],
+		.id = argv[2],
+		.password = argv[3],
+	};
+	
+	if (prof.apn[0] == '\0') {
 		ops->error(ops->ctx, "usage: modem ppp connect <apn>");
 		ops->set_error(-EINVAL, "APN required");
 		return -EINVAL;
@@ -60,7 +65,7 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 		return -EBUSY;
 	}
 
-	ops->set_apn(apn);
+	ops->set_apn(prof.apn);
 
 	ops->print(ops->ctx, "PPP connect: ensure modem powered");
 	ret = ops->ensure_powered(ops->ctx);
@@ -70,7 +75,7 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 	}
 
 	ops->print(ops->ctx, "PPP connect: configure PDP/APN context");
-	ret = ops->configure_context(ops->ctx, apn);
+	ret = ops->configure_context(ops->ctx, &prof);
 	if (ret != 0) {
 		failedStage = "configure_context";
 		goto out_fail;

--- a/platform/src/modem-net/modem-net-core.c
+++ b/platform/src/modem-net/modem-net-core.c
@@ -26,6 +26,7 @@ static const char *modem_net_owner_name(int owner)
 int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, char **argv)
 {
 	const char *apn;
+	const char *failedStage = NULL;
 	int ret;
 
 	if ((ops == NULL) || (ops->owner_get == NULL) || (ops->ensure_powered == NULL) ||
@@ -61,33 +62,45 @@ int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, cha
 
 	ops->set_apn(apn);
 
+	ops->print(ops->ctx, "PPP connect: ensure modem powered");
 	ret = ops->ensure_powered(ops->ctx);
 	if (ret != 0) {
+		failedStage = "ensure_powered";
 		goto out_fail;
 	}
 
+	ops->print(ops->ctx, "PPP connect: configure PDP/APN context");
 	ret = ops->configure_context(ops->ctx, apn);
 	if (ret != 0) {
+		failedStage = "configure_context";
 		goto out_fail;
 	}
 
+	ops->print(ops->ctx, "PPP connect: open UART session");
 	ret = ops->open_uart_session();
 	if (ret != 0) {
+		failedStage = "open_uart_session";
 		goto out_fail;
 	}
 
+	ops->print(ops->ctx, "PPP connect: dial PPP");
 	ret = ops->dial_ppp(ops->ctx);
 	if (ret != 0) {
+		failedStage = "dial_ppp";
 		goto out_close;
 	}
 
+	ops->print(ops->ctx, "PPP connect: attach PPP");
 	ret = ops->attach_ppp();
 	if (ret != 0) {
+		failedStage = "attach_ppp";
 		goto out_close;
 	}
 
+	ops->print(ops->ctx, "PPP connect: wait for network");
 	ret = ops->wait_for_network(ops->ctx);
 	if (ret != 0) {
+		failedStage = "wait_for_network";
 		goto out_close;
 	}
 
@@ -99,7 +112,11 @@ out_close:
 	ops->close_uart_session();
 out_fail:
 	ops->set_error(ret, "connect failed");
-	ops->error(ops->ctx, "connect failed: %d", ret);
+	if (failedStage != NULL) {
+		ops->error(ops->ctx, "connect failed at %s: %d", failedStage, ret);
+	} else {
+		ops->error(ops->ctx, "connect failed: %d", ret);
+	}
 	return ret;
 }
 

--- a/platform/src/modem-net/modem-net-core.h
+++ b/platform/src/modem-net/modem-net-core.h
@@ -19,10 +19,17 @@ struct modem_net_status {
 	const char *ipv4;
 };
 
+
+struct modem_net_profile {
+    const char *apn;
+    const char *id;
+    const char *password;
+};
+
 struct modem_net_ops {
 	int (*owner_get)(void);
 	int (*ensure_powered)(void *ctx);
-	int (*configure_context)(void *ctx, const char *apn);
+	int (*configure_context)(void *ctx, const struct modem_net_profile *prof);
 	int (*open_uart_session)(void);
 	int (*dial_ppp)(void *ctx);
 	int (*attach_ppp)(void);

--- a/platform/src/modem-net/modem-net-core.h
+++ b/platform/src/modem-net/modem-net-core.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct modem_net_status {
+	bool modemPowered;
+	bool sessionOpen;
+	bool connected;
+	bool dnsReady;
+	int uartOwner;
+	int lastError;
+	const char *lastErrorText;
+	const char *apn;
+	const char *ipv4;
+};
+
+struct modem_net_ops {
+	int (*owner_get)(void);
+	int (*ensure_powered)(void *ctx);
+	int (*configure_context)(void *ctx, const char *apn);
+	int (*open_uart_session)(void);
+	int (*dial_ppp)(void *ctx);
+	int (*attach_ppp)(void);
+	int (*wait_for_network)(void *ctx);
+	void (*close_uart_session)(void);
+	int (*escape_and_hangup)(void);
+	int (*get_status)(struct modem_net_status *out);
+	void (*set_apn)(const char *apn);
+	void (*set_error)(int error, const char *message);
+	void (*clear_error)(void);
+	void (*print)(void *ctx, const char *fmt, ...);
+	void (*error)(void *ctx, const char *fmt, ...);
+	void *ctx;
+};
+
+int modem_net_cmd_connect_core(const struct modem_net_ops *ops, size_t argc, char **argv);
+int modem_net_cmd_disconnect_core(const struct modem_net_ops *ops, size_t argc, char **argv);
+int modem_net_cmd_status_core(const struct modem_net_ops *ops, size_t argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/src/modem-net/modem-net-shell.h
+++ b/platform/src/modem-net/modem-net-shell.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stddef.h>
+
+struct shell;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cmd_modem_ppp_connect(const struct shell *sh, size_t argc, char **argv);
+int cmd_modem_ppp_disconnect(const struct shell *sh, size_t argc, char **argv);
+int cmd_modem_ppp_status(const struct shell *sh, size_t argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -459,7 +459,7 @@ static struct modem_net_ops modem_net_make_ops(const struct shell *sh)
 	};
 }
 
-static int cmd_modem_ppp_connect(const struct shell *sh, size_t argc, char **argv)
+int cmd_modem_ppp_connect(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -472,7 +472,7 @@ static int cmd_modem_ppp_connect(const struct shell *sh, size_t argc, char **arg
 	return ret;
 }
 
-static int cmd_modem_ppp_disconnect(const struct shell *sh, size_t argc, char **argv)
+int cmd_modem_ppp_disconnect(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -485,7 +485,7 @@ static int cmd_modem_ppp_disconnect(const struct shell *sh, size_t argc, char **
 	return ret;
 }
 
-static int cmd_modem_ppp_status(const struct shell *sh, size_t argc, char **argv)
+int cmd_modem_ppp_status(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -496,13 +496,3 @@ static int cmd_modem_ppp_status(const struct shell *sh, size_t argc, char **argv
 	return ret;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem_ppp,
-	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: ppp connect <apn>", cmd_modem_ppp_connect, 1, 1),
-	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_modem_ppp_disconnect, 1, 0),
-	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_modem_ppp_status, 1, 0),
-	SHELL_SUBCMD_SET_END
-);
-
-SHELL_SUBCMD_ADD((modem), ppp, &sub_modem_ppp,
-		 "Modem PPP control.",
-		 cmd_modem_ppp_status, 1, 0);

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -32,7 +32,7 @@
 #define MODEM_NET_PPP_FRAME_BUFFER_SIZE 128
 #define MODEM_NET_PIPE_WAIT K_SECONDS(2)
 #define MODEM_NET_DIAL_WAIT K_SECONDS(20)
-#define MODEM_NET_CONNECT_WAIT K_SECONDS(60)
+#define MODEM_NET_CONNECT_WAIT K_SECONDS(15)
 #define MODEM_NET_ESCAPE_GUARD_MS 1200
 #define MODEM_NET_DEFAULT_CONTEXT_ID 1
 #define MODEM_NET_AT_IRQ_RX_RING_SIZE 512
@@ -476,15 +476,16 @@ static int modem_net_escape_and_hangup(void)
 {
 	static const uint8_t escapeSequence[] = "+++";
 	static const uint8_t hangupCommand[] = "ATH\r";
-	uint8_t rxBuffer[64];
+
+	if ((modemNetPipe == NULL) || !modemNetSessionOpen) {
+		return 0;
+	}
 
 	k_msleep(MODEM_NET_ESCAPE_GUARD_MS);
 	(void)modem_pipe_transmit(modemNetPipe, escapeSequence, sizeof(escapeSequence) - 1U);
 	k_msleep(MODEM_NET_ESCAPE_GUARD_MS);
-	(void)modem_pipe_receive(modemNetPipe, rxBuffer, sizeof(rxBuffer));
 	(void)modem_pipe_transmit(modemNetPipe, hangupCommand, sizeof(hangupCommand) - 1U);
 	k_msleep(500);
-	(void)modem_pipe_receive(modemNetPipe, rxBuffer, sizeof(rxBuffer));
 	return 0;
 }
 

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -32,7 +32,7 @@
 #define MODEM_NET_PPP_FRAME_BUFFER_SIZE 128
 #define MODEM_NET_PIPE_WAIT K_SECONDS(2)
 #define MODEM_NET_DIAL_WAIT K_SECONDS(20)
-#define MODEM_NET_CONNECT_WAIT K_SECONDS(15)
+#define MODEM_NET_CONNECT_WAIT K_SECONDS(60)
 #define MODEM_NET_ESCAPE_GUARD_MS 1200
 #define MODEM_NET_DEFAULT_CONTEXT_ID 1
 #define MODEM_NET_AT_IRQ_RX_RING_SIZE 512
@@ -49,7 +49,9 @@ static struct ring_buf modemNetAtRxRing;
 static bool modemNetAtRxIrqConfigured;
 static struct modem_pipe *modemNetPipe;
 static struct net_if *modemNetIface;
-static struct net_mgmt_event_callback modemNetMgmtCb;
+static struct net_mgmt_event_callback modemNetMgmtCb_l2; // PPP 
+static struct net_mgmt_event_callback modemNetMgmtCb_l3; // IP 
+static struct net_mgmt_event_callback modemNetMgmtCb_l4; // socket
 static struct k_sem modemNetConnectedSem;
 static struct k_sem modemNetDnsSem;
 static struct k_mutex modemNetLock;
@@ -156,6 +158,7 @@ static void modem_net_event_handler(struct net_mgmt_event_callback *cb,
 				      struct net_if *iface)
 {
 	ARG_UNUSED(cb);
+	printk("Network Event Fired: 0x%08X\n", (uint32_t)mgmtEvent);
 
 	if ((modemNetIface != NULL) && (iface != modemNetIface)) {
 		return;
@@ -182,24 +185,37 @@ static void modem_net_event_handler(struct net_mgmt_event_callback *cb,
 
 static void modem_net_init_once(void)
 {
-	if (modemNetInitialized) {
-		return;
-	}
+    if (modemNetInitialized) {
+        return;
+    }
 
-	k_sem_init(&modemNetConnectedSem, 0, 1);
-	k_sem_init(&modemNetDnsSem, 0, 1);
-	k_mutex_init(&modemNetLock);
-	net_mgmt_init_event_callback(&modemNetMgmtCb,
-				     modem_net_event_handler,
-				     NET_EVENT_L4_CONNECTED |
-				     NET_EVENT_L4_DISCONNECTED |
-				     NET_EVENT_IPV4_ADDR_ADD |
-				     NET_EVENT_DNS_SERVER_ADD |
-				     NET_EVENT_PPP_PHASE_RUNNING |
-				     NET_EVENT_PPP_PHASE_DEAD |
-				     NET_EVENT_PPP_CARRIER_OFF);
-	net_mgmt_add_event_callback(&modemNetMgmtCb);
-	modemNetInitialized = true;
+    k_sem_init(&modemNetConnectedSem, 0, 1);
+    k_sem_init(&modemNetDnsSem, 0, 1);
+    k_mutex_init(&modemNetLock);
+
+    // 1. L2 (PPP) 
+    net_mgmt_init_event_callback(&modemNetMgmtCb_l2,
+                                 modem_net_event_handler,
+                                 NET_EVENT_PPP_PHASE_RUNNING |
+                                 NET_EVENT_PPP_PHASE_DEAD |
+                                 NET_EVENT_PPP_CARRIER_OFF);
+    net_mgmt_add_event_callback(&modemNetMgmtCb_l2);
+
+    // 2. L3 (IPv4 / DNS)
+    net_mgmt_init_event_callback(&modemNetMgmtCb_l3,
+                                 modem_net_event_handler,
+                                 NET_EVENT_IPV4_ADDR_ADD |
+                                 NET_EVENT_DNS_SERVER_ADD);
+    net_mgmt_add_event_callback(&modemNetMgmtCb_l3);
+
+    // 3. L4 (Socket)
+    net_mgmt_init_event_callback(&modemNetMgmtCb_l4,
+                                 modem_net_event_handler,
+                                 NET_EVENT_L4_CONNECTED |
+                                 NET_EVENT_L4_DISCONNECTED);
+    net_mgmt_add_event_callback(&modemNetMgmtCb_l4);
+
+    modemNetInitialized = true;
 }
 
 static int modem_net_send_at(const char *command, char *response, size_t responseSize)
@@ -264,6 +280,16 @@ static int modem_net_sync_and_disable_sleep(const struct shell *sh)
 	}
 
 	shell_print(sh, "Sleep disabled: %s", response);
+
+    // disable PSM(Power Saving Mode) 
+	shell_print(sh, "Disabling PSM (CPSMS=0)...");
+	ret = modem_net_send_at("AT+CPSMS=0", response, sizeof(response));
+	shell_print(sh, ":CPSMS: (%s)", (ret == 0) ? response : "FAIL");
+
+	// disable eDRX
+	shell_print(sh, "Disabling eDRX (CEDRXS=0)...");
+	ret = modem_net_send_at("AT+CEDRXS=0", response, sizeof(response));
+	shell_print(sh, ":CEDRXS: (%s)", (ret == 0) ? response : "FAIL");	
 	return 0;
 }
 
@@ -301,24 +327,55 @@ static int modem_net_configure_context(void *ctx, const char *apn)
 		return -EINVAL;
 	}
 
+    shell_print(sh, "Resetting network stack (CFUN=4)...");
+    (void)modem_net_send_at("AT+CFUN=4", response, sizeof(response));	
+    shell_print(sh, ":CFUN=4: (%s)", (ret == 0) ? response : "FAIL");
+
+    shell_print(sh, "Pre-activating network (CFUN=1)...");
+    (void)modem_net_send_at("AT+CFUN=1", response, sizeof(response));
+    shell_print(sh, ":CFUN=1: (%s)", (ret == 0) ? response : "FAIL");
+
+	(void)modem_net_send_at("AT+CMEE=1", response, sizeof(response));
+    shell_print(sh, ":CMEE=0: (%s)", (ret == 0) ? response : "FAIL");
+
 	snprintk(command, sizeof(command), "AT+CGDCONT=%d,\"IP\",\"%s\"",
-		 MODEM_NET_DEFAULT_CONTEXT_ID,
-		 apn);
+			MODEM_NET_DEFAULT_CONTEXT_ID, apn);
 	shell_print(sh, "Configuring PDP context (%s)...", apn);
 	ret = modem_net_send_at(command, response, sizeof(response));
 	if (ret != 0) {
 		return ret;
 	}
-
-	ret = modem_net_send_at("AT+CGATT=1", response, sizeof(response));
-	if ((ret != 0) && (ret != -EIO)) {
+	
+	snprintk(command, sizeof(command), "AT+KCNXCFG=%d,\"GPRS\",\"%s\",,,\"IPV4\"",
+			MODEM_NET_DEFAULT_CONTEXT_ID, apn);
+	shell_print(sh, "Configuring Connection Profile (Reference Style)...");
+	ret = modem_net_send_at(command, response, sizeof(response));
+	if (ret != 0) {
 		return ret;
 	}
+    ret = modem_net_send_at("AT+WPPP=0", response, sizeof(response));
+    shell_print(sh, ":WPPP=0: (%s)", (ret == 0) ? response : "FAIL");
 
-	ret = modem_net_send_at("AT+CGACT=1,1", response, sizeof(response));
-	if ((ret != 0) && (ret != -EIO)) {
-		return ret;
-	}
+    // Waiting for registration
+    shell_print(sh, "Waiting for network registration (CREG/CEREG)...");
+	int registration_attempts = 10; // max 10secs
+    while (registration_attempts-- > 0) {
+        ret = modem_net_send_at("AT+CEREG?", response, sizeof(response));
+        
+        // check response of  "+CEREG: 0,1" (home) or "+CEREG: 0,5" (roaming)
+        if (ret == 0 && (strstr(response, "0,1") || strstr(response, "0,5"))) {
+            shell_print(sh, "Network registered: %s", response);
+            break;
+        }
+        
+        shell_print(sh, "Still searching... (%d)", registration_attempts);
+        k_msleep(1000);
+        
+        if (registration_attempts == 0) {
+            shell_error(sh, "Failed to register on network within timeout");
+            return -ETIMEDOUT;
+        }
+    }
 
 	return 0;
 }
@@ -396,7 +453,7 @@ static int modem_net_dial_ppp(void *ctx)
 	char response[MODEM_NET_AT_RESPONSE_SIZE] = {0};
 	int ret;
 
-	shell_print(sh, "Dialing PPP...");
+	shell_print(sh, "Dialing PPP...(%s)\n", dialCommand );
 	ret = modem_pipe_transmit(modemNetPipe,
 				 (const uint8_t *)dialCommand,
 				 sizeof(dialCommand) - 1U);

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -124,6 +124,23 @@ static int modem_net_send_at(const char *command, char *response, size_t respons
 	return modem_at_send(command, response, responseSize);
 }
 
+static void modem_net_log_at_diagnostics(const struct shell *sh, const char *label, int ret,
+					      const char *response)
+{
+	struct modem_at_diagnostics diagnostics = {0};
+
+	modem_at_get_last_diagnostics(&diagnostics);
+	shell_error(sh,
+		    "%s failed: %d (saw_bytes=%s bytes=%u exit=%s last_uart_ret=%d response='%s')",
+		    label,
+		    ret,
+		    diagnostics.sawAnyByte ? "yes" : "no",
+		    (unsigned int)diagnostics.bytesReceived,
+		    modem_at_exit_reason_str(diagnostics.exitReason),
+		    diagnostics.lastUartRet,
+		    (response != NULL) ? response : "");
+}
+
 static int modem_net_sync_and_disable_sleep(const struct shell *sh)
 {
 	char response[MODEM_NET_AT_RESPONSE_SIZE];
@@ -133,18 +150,31 @@ static int modem_net_sync_and_disable_sleep(const struct shell *sh)
 	k_msleep(MODEM_NET_BOOT_DELAY_MS);
 
 	for (int attempt = 0; attempt < MODEM_NET_SYNC_RETRIES; ++attempt) {
+		response[0] = '\0';
+		shell_print(sh, "AT sync attempt %d/%d...", attempt + 1, MODEM_NET_SYNC_RETRIES);
 		ret = modem_net_send_at("AT", response, sizeof(response));
 		if (ret == 0) {
+			shell_print(sh, "AT sync OK: %s", response);
 			break;
 		}
+
+		modem_net_log_at_diagnostics(sh, "AT sync", ret, response);
 	}
 
 	if (ret != 0) {
 		return ret;
 	}
 
+	response[0] = '\0';
 	shell_print(sh, "Disabling sleep...");
-	return modem_net_send_at("AT+KSLEEP=2", response, sizeof(response));
+	ret = modem_net_send_at("AT+KSLEEP=2", response, sizeof(response));
+	if (ret != 0) {
+		modem_net_log_at_diagnostics(sh, "AT+KSLEEP=2", ret, response);
+		return ret;
+	}
+
+	shell_print(sh, "Sleep disabled: %s", response);
+	return 0;
 }
 
 static int modem_net_ensure_powered(void *ctx)

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -328,15 +328,16 @@ static int modem_net_configure_context(void *ctx, const char *apn)
 	}
 
     shell_print(sh, "Resetting network stack (CFUN=4)...");
-    (void)modem_net_send_at("AT+CFUN=4", response, sizeof(response));	
+    ret = modem_net_send_at("AT+CFUN=4", response, sizeof(response));	
     shell_print(sh, ":CFUN=4: (%s)", (ret == 0) ? response : "FAIL");
 
     shell_print(sh, "Pre-activating network (CFUN=1)...");
-    (void)modem_net_send_at("AT+CFUN=1", response, sizeof(response));
+    ret = modem_net_send_at("AT+CFUN=1", response, sizeof(response));
     shell_print(sh, ":CFUN=1: (%s)", (ret == 0) ? response : "FAIL");
 
-	(void)modem_net_send_at("AT+CMEE=1", response, sizeof(response));
-    shell_print(sh, ":CMEE=0: (%s)", (ret == 0) ? response : "FAIL");
+	shell_print(sh, "Enabling verbose modem error reporting (CMEE=1)...");
+	ret = modem_net_send_at("AT+CMEE=1", response, sizeof(response));
+	shell_print(sh, ":CMEE=0: (%s)", (ret == 0) ? response : "FAIL");
 
 	snprintk(command, sizeof(command), "AT+CGDCONT=%d,\"IP\",\"%s\"",
 			MODEM_NET_DEFAULT_CONTEXT_ID, apn);

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -1,0 +1,496 @@
+#include "modem-at.h"
+#include "modem-board.h"
+#include "modem-net-core.h"
+#include "modem-shell-uart.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
+#include <zephyr/modem/backend/uart.h>
+#include <zephyr/modem/pipe.h>
+#include <zephyr/modem/ppp.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/shell/shell.h>
+
+#define MODEM_NET_BOOT_DELAY_MS 10000
+#define MODEM_NET_SYNC_RETRIES 3
+#define MODEM_NET_AT_RESPONSE_SIZE 256
+#define MODEM_NET_UART_RX_BUFFER_SIZE 512
+#define MODEM_NET_UART_TX_BUFFER_SIZE 512
+#define MODEM_NET_PPP_FRAME_BUFFER_SIZE 128
+#define MODEM_NET_PIPE_WAIT K_SECONDS(2)
+#define MODEM_NET_DIAL_WAIT K_SECONDS(20)
+#define MODEM_NET_CONNECT_WAIT K_SECONDS(60)
+#define MODEM_NET_ESCAPE_GUARD_MS 1200
+#define MODEM_NET_DEFAULT_CONTEXT_ID 1
+
+MODEM_PPP_DEFINE(modemNetPpp, NULL, 98, 1500, MODEM_NET_PPP_FRAME_BUFFER_SIZE);
+
+static const struct device *const modemUart = DEVICE_DT_GET(DT_NODELABEL(modem_uart));
+static struct modem_backend_uart modemNetBackend;
+static uint8_t modemNetBackendRxBuffer[MODEM_NET_UART_RX_BUFFER_SIZE];
+static uint8_t modemNetBackendTxBuffer[MODEM_NET_UART_TX_BUFFER_SIZE];
+static struct modem_pipe *modemNetPipe;
+static struct net_if *modemNetIface;
+static struct net_mgmt_event_callback modemNetMgmtCb;
+static struct k_sem modemNetConnectedSem;
+static struct k_sem modemNetDnsSem;
+static struct k_mutex modemNetLock;
+static bool modemNetInitialized;
+static bool modemNetSessionOpen;
+static bool modemNetPppAttached;
+static bool modemNetConnected;
+static bool modemNetDnsReady;
+static int modemNetLastError;
+static char modemNetLastErrorText[96];
+static char modemNetApn[64];
+
+static void modem_net_set_error(int error, const char *message)
+{
+	modemNetLastError = error;
+	snprintk(modemNetLastErrorText, sizeof(modemNetLastErrorText), "%s", message);
+}
+
+static void modem_net_clear_error(void)
+{
+	modemNetLastError = 0;
+	modemNetLastErrorText[0] = '\0';
+}
+
+static void modem_net_event_handler(struct net_mgmt_event_callback *cb,
+				      uint64_t mgmtEvent,
+				      struct net_if *iface)
+{
+	ARG_UNUSED(cb);
+
+	if ((modemNetIface != NULL) && (iface != modemNetIface)) {
+		return;
+	}
+
+	if ((mgmtEvent == NET_EVENT_L4_CONNECTED) ||
+	    (mgmtEvent == NET_EVENT_IPV4_ADDR_ADD) ||
+	    (mgmtEvent == NET_EVENT_PPP_PHASE_RUNNING)) {
+		modemNetConnected = true;
+		k_sem_give(&modemNetConnectedSem);
+	}
+
+	if (mgmtEvent == NET_EVENT_DNS_SERVER_ADD) {
+		modemNetDnsReady = true;
+		k_sem_give(&modemNetDnsSem);
+	}
+
+	if ((mgmtEvent == NET_EVENT_L4_DISCONNECTED) ||
+	    (mgmtEvent == NET_EVENT_PPP_PHASE_DEAD) ||
+	    (mgmtEvent == NET_EVENT_PPP_CARRIER_OFF)) {
+		modemNetConnected = false;
+	}
+}
+
+static void modem_net_init_once(void)
+{
+	if (modemNetInitialized) {
+		return;
+	}
+
+	k_sem_init(&modemNetConnectedSem, 0, 1);
+	k_sem_init(&modemNetDnsSem, 0, 1);
+	k_mutex_init(&modemNetLock);
+	net_mgmt_init_event_callback(&modemNetMgmtCb,
+				     modem_net_event_handler,
+				     NET_EVENT_L4_CONNECTED |
+				     NET_EVENT_L4_DISCONNECTED |
+				     NET_EVENT_IPV4_ADDR_ADD |
+				     NET_EVENT_DNS_SERVER_ADD |
+				     NET_EVENT_PPP_PHASE_RUNNING |
+				     NET_EVENT_PPP_PHASE_DEAD |
+				     NET_EVENT_PPP_CARRIER_OFF);
+	net_mgmt_add_event_callback(&modemNetMgmtCb);
+	modemNetInitialized = true;
+}
+
+static int modem_net_send_at(const char *command, char *response, size_t responseSize)
+{
+	return modem_at_send(command, response, responseSize);
+}
+
+static int modem_net_sync_and_disable_sleep(const struct shell *sh)
+{
+	char response[MODEM_NET_AT_RESPONSE_SIZE];
+	int ret = -ETIMEDOUT;
+
+	shell_print(sh, "Waiting 10s for modem boot...");
+	k_msleep(MODEM_NET_BOOT_DELAY_MS);
+
+	for (int attempt = 0; attempt < MODEM_NET_SYNC_RETRIES; ++attempt) {
+		ret = modem_net_send_at("AT", response, sizeof(response));
+		if (ret == 0) {
+			break;
+		}
+	}
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	shell_print(sh, "Disabling sleep...");
+	return modem_net_send_at("AT+KSLEEP=2", response, sizeof(response));
+}
+
+static int modem_net_ensure_powered(const struct shell *sh)
+{
+	struct modem_board_status status;
+	int ret = modem_board_get_status(&status);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (status.rail_en == 1) {
+		return 0;
+	}
+
+	shell_print(sh, "Powering modem...");
+	ret = modem_board_power_on();
+	if (ret != 0) {
+		return ret;
+	}
+
+	return modem_net_sync_and_disable_sleep(sh);
+}
+
+static int modem_net_configure_context(const struct shell *sh, const char *apn)
+{
+	char command[96];
+	char response[MODEM_NET_AT_RESPONSE_SIZE];
+	int ret;
+
+	if ((apn == NULL) || (apn[0] == '\0')) {
+		shell_error(sh, "APN is not configured");
+		return -EINVAL;
+	}
+
+	snprintk(command, sizeof(command), "AT+CGDCONT=%d,\"IP\",\"%s\"",
+		 MODEM_NET_DEFAULT_CONTEXT_ID,
+		 apn);
+	shell_print(sh, "Configuring PDP context (%s)...", apn);
+	ret = modem_net_send_at(command, response, sizeof(response));
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = modem_net_send_at("AT+CGATT=1", response, sizeof(response));
+	if ((ret != 0) && (ret != -EIO)) {
+		return ret;
+	}
+
+	ret = modem_net_send_at("AT+CGACT=1,1", response, sizeof(response));
+	if ((ret != 0) && (ret != -EIO)) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int modem_net_open_uart_session(void)
+{
+	const struct modem_backend_uart_config config = {
+		.uart = modemUart,
+		.receive_buf = modemNetBackendRxBuffer,
+		.receive_buf_size = sizeof(modemNetBackendRxBuffer),
+		.transmit_buf = modemNetBackendTxBuffer,
+		.transmit_buf_size = sizeof(modemNetBackendTxBuffer),
+	};
+	int ret;
+
+	if (!device_is_ready(modemUart)) {
+		return -ENODEV;
+	}
+
+	ret = modem_uart_owner_acquire(MODEM_UART_OWNER_PPP);
+	if (ret != 0) {
+		return ret;
+	}
+
+	modemNetPipe = modem_backend_uart_init(&modemNetBackend, &config);
+	if (modemNetPipe == NULL) {
+		modem_uart_owner_release(MODEM_UART_OWNER_PPP);
+		return -ENODEV;
+	}
+
+	ret = modem_pipe_open(modemNetPipe, MODEM_NET_PIPE_WAIT);
+	if (ret != 0) {
+		modem_uart_owner_release(MODEM_UART_OWNER_PPP);
+		modemNetPipe = NULL;
+		return ret;
+	}
+
+	modemNetSessionOpen = true;
+	return 0;
+}
+
+static int modem_net_wait_for_connect_text(char *buffer, size_t bufferSize)
+{
+	int64_t deadline = k_uptime_get() + k_ticks_to_ms_floor64(MODEM_NET_DIAL_WAIT.ticks);
+	size_t used = 0U;
+
+	while (k_uptime_get() < deadline) {
+		int ret = modem_pipe_receive(modemNetPipe,
+					    (uint8_t *)&buffer[used],
+					    bufferSize - used - 1U);
+		if (ret > 0) {
+			used += (size_t)ret;
+			buffer[used] = '\0';
+			if (strstr(buffer, "CONNECT") != NULL) {
+				return 0;
+			}
+			if (strstr(buffer, "NO CARRIER") != NULL) {
+				return -ENOTCONN;
+			}
+			if (strstr(buffer, "ERROR") != NULL) {
+				return -EIO;
+			}
+		}
+
+		k_msleep(20);
+	}
+
+	return -ETIMEDOUT;
+}
+
+static int modem_net_dial_ppp(const struct shell *sh)
+{
+	static const char dialCommand[] = "ATD*99***1#\r";
+	char response[MODEM_NET_AT_RESPONSE_SIZE] = {0};
+	int ret;
+
+	shell_print(sh, "Dialing PPP...");
+	ret = modem_pipe_transmit(modemNetPipe,
+				 (const uint8_t *)dialCommand,
+				 sizeof(dialCommand) - 1U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = modem_net_wait_for_connect_text(response, sizeof(response));
+	if (ret != 0) {
+		return ret;
+	}
+
+	shell_print(sh, "PPP data mode entered");
+	return 0;
+}
+
+static int modem_net_attach_ppp(void)
+{
+	int ret = modem_ppp_attach(&modemNetPpp, modemNetPipe);
+	if (ret != 0) {
+		return ret;
+	}
+
+	modemNetPppAttached = true;
+	modemNetIface = modem_ppp_get_iface(&modemNetPpp);
+	if (modemNetIface == NULL) {
+		return -ENODEV;
+	}
+
+	net_if_carrier_on(modemNetIface);
+	return net_if_up(modemNetIface);
+}
+
+static int modem_net_wait_for_network(const struct shell *sh)
+{
+	int ret;
+
+	shell_print(sh, "Waiting for IP link...");
+	ret = k_sem_take(&modemNetConnectedSem, MODEM_NET_CONNECT_WAIT);
+	if (ret != 0) {
+		return -ETIMEDOUT;
+	}
+
+	shell_print(sh, "Waiting for DNS...");
+	(void)k_sem_take(&modemNetDnsSem, K_SECONDS(10));
+	return 0;
+}
+
+static void modem_net_close_uart_session(void)
+{
+	if (modemNetPppAttached) {
+		modem_ppp_release(&modemNetPpp);
+		modemNetPppAttached = false;
+	}
+
+	if (modemNetIface != NULL) {
+		net_if_carrier_off(modemNetIface);
+		(void)net_if_down(modemNetIface);
+	}
+
+	if (modemNetSessionOpen && (modemNetPipe != NULL)) {
+		(void)modem_pipe_close(modemNetPipe, MODEM_NET_PIPE_WAIT);
+	}
+
+	modemNetPipe = NULL;
+	modemNetIface = NULL;
+	modemNetSessionOpen = false;
+	modemNetConnected = false;
+	modemNetDnsReady = false;
+	k_sem_reset(&modemNetConnectedSem);
+	k_sem_reset(&modemNetDnsSem);
+	modem_uart_owner_release(MODEM_UART_OWNER_PPP);
+}
+
+static int modem_net_escape_and_hangup(void)
+{
+	static const uint8_t escapeSequence[] = "+++";
+	static const uint8_t hangupCommand[] = "ATH\r";
+	uint8_t rxBuffer[64];
+
+	k_msleep(MODEM_NET_ESCAPE_GUARD_MS);
+	(void)modem_pipe_transmit(modemNetPipe, escapeSequence, sizeof(escapeSequence) - 1U);
+	k_msleep(MODEM_NET_ESCAPE_GUARD_MS);
+	(void)modem_pipe_receive(modemNetPipe, rxBuffer, sizeof(rxBuffer));
+	(void)modem_pipe_transmit(modemNetPipe, hangupCommand, sizeof(hangupCommand) - 1U);
+	k_msleep(500);
+	(void)modem_pipe_receive(modemNetPipe, rxBuffer, sizeof(rxBuffer));
+	return 0;
+}
+
+static void modem_net_shell_print(void *ctx, const char *fmt, ...)
+{
+	const struct shell *sh = ctx;
+	va_list args;
+
+	va_start(args, fmt);
+	shell_vfprintf(sh, SHELL_NORMAL, fmt, args);
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+	va_end(args);
+}
+
+static void modem_net_shell_error(void *ctx, const char *fmt, ...)
+{
+	const struct shell *sh = ctx;
+	va_list args;
+
+	va_start(args, fmt);
+	shell_vfprintf(sh, SHELL_ERROR, fmt, args);
+	shell_fprintf(sh, SHELL_ERROR, "\n");
+	va_end(args);
+}
+
+static void modem_net_set_apn(const char *apn)
+{
+	snprintk(modemNetApn, sizeof(modemNetApn), "%s", apn);
+}
+
+static int modem_net_get_status(struct modem_net_status *out)
+{
+	struct modem_board_status boardStatus;
+	char *ipv4 = NULL;
+	int ret;
+
+	if (out == NULL) {
+		return -EINVAL;
+	}
+
+	ret = modem_board_get_status(&boardStatus);
+	if (ret != 0) {
+		return ret;
+	}
+
+	memset(out, 0, sizeof(*out));
+	out->modemPowered = boardStatus.modem_state_on;
+	out->sessionOpen = modemNetSessionOpen;
+	out->connected = modemNetConnected;
+	out->dnsReady = modemNetDnsReady;
+	out->uartOwner = modem_uart_owner_get();
+	out->lastError = modemNetLastError;
+	out->lastErrorText = modemNetLastErrorText;
+	out->apn = (modemNetApn[0] != '\0') ? modemNetApn : NULL;
+
+	if (modemNetIface != NULL) {
+		struct in_addr *addr = net_if_ipv4_get_global_addr(modemNetIface, NET_ADDR_PREFERRED);
+		static char ipv4Buffer[NET_IPV4_ADDR_LEN];
+		if (addr != NULL) {
+			ipv4 = net_addr_ntop(AF_INET, addr, ipv4Buffer, sizeof(ipv4Buffer));
+		}
+	}
+
+	out->ipv4 = ipv4;
+	return 0;
+}
+
+static struct modem_net_ops modem_net_make_ops(const struct shell *sh)
+{
+	return (struct modem_net_ops){
+		.owner_get = modem_uart_owner_get,
+		.ensure_powered = modem_net_ensure_powered,
+		.configure_context = modem_net_configure_context,
+		.open_uart_session = modem_net_open_uart_session,
+		.dial_ppp = modem_net_dial_ppp,
+		.attach_ppp = modem_net_attach_ppp,
+		.wait_for_network = modem_net_wait_for_network,
+		.close_uart_session = modem_net_close_uart_session,
+		.escape_and_hangup = modem_net_escape_and_hangup,
+		.get_status = modem_net_get_status,
+		.set_apn = modem_net_set_apn,
+		.set_error = modem_net_set_error,
+		.clear_error = modem_net_clear_error,
+		.print = modem_net_shell_print,
+		.error = modem_net_shell_error,
+		.ctx = (void *)sh,
+	};
+}
+
+static int cmd_net_connect(const struct shell *sh, size_t argc, char **argv)
+{
+	int ret;
+	struct modem_net_ops ops;
+
+	modem_net_init_once();
+	k_mutex_lock(&modemNetLock, K_FOREVER);
+	ops = modem_net_make_ops(sh);
+	ret = modem_net_cmd_connect_core(&ops, argc, argv);
+	k_mutex_unlock(&modemNetLock);
+	return ret;
+}
+
+static int cmd_net_disconnect(const struct shell *sh, size_t argc, char **argv)
+{
+	int ret;
+	struct modem_net_ops ops;
+
+	modem_net_init_once();
+	k_mutex_lock(&modemNetLock, K_FOREVER);
+	ops = modem_net_make_ops(sh);
+	ret = modem_net_cmd_disconnect_core(&ops, argc, argv);
+	k_mutex_unlock(&modemNetLock);
+	return ret;
+}
+
+static int cmd_net_status(const struct shell *sh, size_t argc, char **argv)
+{
+	int ret;
+	struct modem_net_ops ops;
+
+	modem_net_init_once();
+	ops = modem_net_make_ops(sh);
+	ret = modem_net_cmd_status_core(&ops, argc, argv);
+	return ret;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_net,
+	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: connect <apn>", cmd_net_connect, 1, 1),
+	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_net_disconnect, 1, 0),
+	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_net_status, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(net, &sub_net, "PPP network control", NULL);

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -22,6 +22,7 @@
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/sys/ring_buffer.h>
 
 #define MODEM_NET_BOOT_DELAY_MS 10000
 #define MODEM_NET_SYNC_RETRIES 3
@@ -34,6 +35,8 @@
 #define MODEM_NET_CONNECT_WAIT K_SECONDS(60)
 #define MODEM_NET_ESCAPE_GUARD_MS 1200
 #define MODEM_NET_DEFAULT_CONTEXT_ID 1
+#define MODEM_NET_AT_IRQ_RX_RING_SIZE 512
+#define MODEM_NET_AT_IRQ_RX_CHUNK_SIZE 64
 
 MODEM_PPP_DEFINE(modemNetPpp, NULL, 98, 1500, MODEM_NET_PPP_FRAME_BUFFER_SIZE);
 
@@ -41,6 +44,9 @@ static const struct device *const modemUart = DEVICE_DT_GET(DT_NODELABEL(modem_u
 static struct modem_backend_uart modemNetBackend;
 static uint8_t modemNetBackendRxBuffer[MODEM_NET_UART_RX_BUFFER_SIZE];
 static uint8_t modemNetBackendTxBuffer[MODEM_NET_UART_TX_BUFFER_SIZE];
+static uint8_t modemNetAtRxRingBuffer[MODEM_NET_AT_IRQ_RX_RING_SIZE];
+static struct ring_buf modemNetAtRxRing;
+static bool modemNetAtRxIrqConfigured;
 static struct modem_pipe *modemNetPipe;
 static struct net_if *modemNetIface;
 static struct net_mgmt_event_callback modemNetMgmtCb;
@@ -66,6 +72,83 @@ static void modem_net_clear_error(void)
 {
 	modemNetLastError = 0;
 	modemNetLastErrorText[0] = '\0';
+}
+
+static void modem_net_uart_rx_irq_cb(const struct device *dev, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	uint8_t buffer[MODEM_NET_AT_IRQ_RX_CHUNK_SIZE];
+
+	uart_irq_update(dev);
+
+	while (uart_irq_rx_ready(dev)) {
+		int received = uart_fifo_read(dev, buffer, sizeof(buffer));
+		if (received <= 0) {
+			break;
+		}
+
+		(void)ring_buf_put(&modemNetAtRxRing, buffer, (uint32_t)received);
+	}
+}
+
+static int modem_net_at_rx_prepare(void)
+{
+	if (!device_is_ready(modemUart)) {
+		return -ENODEV;
+	}
+
+	if (!modemNetAtRxIrqConfigured) {
+		ring_buf_init(&modemNetAtRxRing,
+			      sizeof(modemNetAtRxRingBuffer),
+			      modemNetAtRxRingBuffer);
+		uart_irq_callback_user_data_set(modemUart, modem_net_uart_rx_irq_cb, NULL);
+		modemNetAtRxIrqConfigured = true;
+	}
+
+	return 0;
+}
+
+static uint32_t modem_net_uart_rx_read(void *ctx, uint8_t *buffer, size_t bufferSize)
+{
+	ARG_UNUSED(ctx);
+	return ring_buf_get(&modemNetAtRxRing, buffer, bufferSize);
+}
+
+static int modem_net_irq_at_session_open(void *ctx, char *response, size_t responseSize)
+{
+	ARG_UNUSED(ctx);
+	int ret;
+
+	if ((response == NULL) || (responseSize == 0U)) {
+		return -EINVAL;
+	}
+
+	ret = modem_net_at_rx_prepare();
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = modem_uart_owner_acquire(MODEM_UART_OWNER_AT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ring_buf_reset(&modemNetAtRxRing);
+	uart_irq_rx_enable(modemUart);
+	response[0] = '\0';
+	return 0;
+}
+
+static void modem_net_irq_at_session_close(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	if (modem_uart_owner_get() == MODEM_UART_OWNER_AT) {
+		uart_irq_rx_disable(modemUart);
+		ring_buf_reset(&modemNetAtRxRing);
+		modem_uart_owner_release(MODEM_UART_OWNER_AT);
+	}
 }
 
 static void modem_net_event_handler(struct net_mgmt_event_callback *cb,
@@ -121,7 +204,14 @@ static void modem_net_init_once(void)
 
 static int modem_net_send_at(const char *command, char *response, size_t responseSize)
 {
-	return modem_at_send(command, response, responseSize);
+	static const struct modem_at_irq_transport transport = {
+		.ctx = NULL,
+		.open = modem_net_irq_at_session_open,
+		.close = modem_net_irq_at_session_close,
+		.read = modem_net_uart_rx_read,
+	};
+
+	return modem_at_send_irq(command, response, responseSize, &transport, NULL);
 }
 
 static void modem_net_log_at_diagnostics(const struct shell *sh, const char *label, int ret,

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -345,15 +345,18 @@ static int modem_net_configure_context(void *ctx, const char *apn)
 	if (ret != 0) {
 		return ret;
 	}
+
+	// ID/Password = a/b
+    snprintk(command, sizeof(command), "AT+KCNXCFG=%d,\"GPRS\",\"%s\",\"a\",\"b\",\"IPV4\"",
+             MODEM_NET_DEFAULT_CONTEXT_ID, apn);
+    
+    shell_print(sh, "Configuring Connection Profile (Reference Style)...");
+    ret = modem_net_send_at(command, response, sizeof(response));
+    if (ret != 0) {
+        return ret;
+    }
 	
-	snprintk(command, sizeof(command), "AT+KCNXCFG=%d,\"GPRS\",\"%s\",,,\"IPV4\"",
-			MODEM_NET_DEFAULT_CONTEXT_ID, apn);
-	shell_print(sh, "Configuring Connection Profile (Reference Style)...");
-	ret = modem_net_send_at(command, response, sizeof(response));
-	if (ret != 0) {
-		return ret;
-	}
-    ret = modem_net_send_at("AT+WPPP=0", response, sizeof(response));
+	ret = modem_net_send_at("AT+WPPP=0", response, sizeof(response));
     shell_print(sh, ":WPPP=0: (%s)", (ret == 0) ? response : "FAIL");
 
     // Waiting for registration

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -315,14 +315,14 @@ static int modem_net_ensure_powered(void *ctx)
 	return modem_net_sync_and_disable_sleep(sh);
 }
 
-static int modem_net_configure_context(void *ctx, const char *apn)
+static int modem_net_configure_context(void *ctx, const struct modem_net_profile *prof)
 {
 	const struct shell *sh = ctx;
 	char command[96];
 	char response[MODEM_NET_AT_RESPONSE_SIZE];
 	int ret;
 
-	if ((apn == NULL) || (apn[0] == '\0')) {
+	if ((prof == NULL) || (prof->apn == NULL) || (prof->apn[0] == '\0')) {
 		shell_error(sh, "APN is not configured");
 		return -EINVAL;
 	}
@@ -340,16 +340,16 @@ static int modem_net_configure_context(void *ctx, const char *apn)
 	shell_print(sh, ":CMEE=0: (%s)", (ret == 0) ? response : "FAIL");
 
 	snprintk(command, sizeof(command), "AT+CGDCONT=%d,\"IP\",\"%s\"",
-			MODEM_NET_DEFAULT_CONTEXT_ID, apn);
-	shell_print(sh, "Configuring PDP context (%s)...", apn);
+			MODEM_NET_DEFAULT_CONTEXT_ID, prof->apn);
+	shell_print(sh, "Configuring PDP context (%s)...", prof->apn);
 	ret = modem_net_send_at(command, response, sizeof(response));
 	if (ret != 0) {
 		return ret;
 	}
 
 	// ID/Password = a/b
-    snprintk(command, sizeof(command), "AT+KCNXCFG=%d,\"GPRS\",\"%s\",\"a\",\"b\",\"IPV4\"",
-             MODEM_NET_DEFAULT_CONTEXT_ID, apn);
+    snprintk(command, sizeof(command), "AT+KCNXCFG=%d,\"GPRS\",\"%s\",\"%s\",\"%s\",\"IPV4\"",
+             MODEM_NET_DEFAULT_CONTEXT_ID, prof->apn, prof->id, prof->password);
     
     shell_print(sh, "Configuring Connection Profile (Reference Style)...");
     ret = modem_net_send_at(command, response, sizeof(response));

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -16,6 +16,7 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/ppp.h>
 #include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/ppp.h>
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
@@ -146,8 +147,9 @@ static int modem_net_sync_and_disable_sleep(const struct shell *sh)
 	return modem_net_send_at("AT+KSLEEP=2", response, sizeof(response));
 }
 
-static int modem_net_ensure_powered(const struct shell *sh)
+static int modem_net_ensure_powered(void *ctx)
 {
+	const struct shell *sh = ctx;
 	struct modem_board_status status;
 	int ret = modem_board_get_status(&status);
 	if (ret != 0) {
@@ -167,8 +169,9 @@ static int modem_net_ensure_powered(const struct shell *sh)
 	return modem_net_sync_and_disable_sleep(sh);
 }
 
-static int modem_net_configure_context(const struct shell *sh, const char *apn)
+static int modem_net_configure_context(void *ctx, const char *apn)
 {
+	const struct shell *sh = ctx;
 	char command[96];
 	char response[MODEM_NET_AT_RESPONSE_SIZE];
 	int ret;
@@ -266,8 +269,9 @@ static int modem_net_wait_for_connect_text(char *buffer, size_t bufferSize)
 	return -ETIMEDOUT;
 }
 
-static int modem_net_dial_ppp(const struct shell *sh)
+static int modem_net_dial_ppp(void *ctx)
 {
+	const struct shell *sh = ctx;
 	static const char dialCommand[] = "ATD*99***1#\r";
 	char response[MODEM_NET_AT_RESPONSE_SIZE] = {0};
 	int ret;
@@ -306,8 +310,9 @@ static int modem_net_attach_ppp(void)
 	return net_if_up(modemNetIface);
 }
 
-static int modem_net_wait_for_network(const struct shell *sh)
+static int modem_net_wait_for_network(void *ctx)
 {
+	const struct shell *sh = ctx;
 	int ret;
 
 	shell_print(sh, "Waiting for IP link...");
@@ -390,6 +395,11 @@ static void modem_net_set_apn(const char *apn)
 	snprintk(modemNetApn, sizeof(modemNetApn), "%s", apn);
 }
 
+static int modem_net_owner_get(void)
+{
+	return (int)modem_uart_owner_get();
+}
+
 static int modem_net_get_status(struct modem_net_status *out)
 {
 	struct modem_board_status boardStatus;
@@ -430,7 +440,7 @@ static int modem_net_get_status(struct modem_net_status *out)
 static struct modem_net_ops modem_net_make_ops(const struct shell *sh)
 {
 	return (struct modem_net_ops){
-		.owner_get = modem_uart_owner_get,
+		.owner_get = modem_net_owner_get,
 		.ensure_powered = modem_net_ensure_powered,
 		.configure_context = modem_net_configure_context,
 		.open_uart_session = modem_net_open_uart_session,

--- a/platform/src/modem-net/modem-net.c
+++ b/platform/src/modem-net/modem-net.c
@@ -459,7 +459,7 @@ static struct modem_net_ops modem_net_make_ops(const struct shell *sh)
 	};
 }
 
-static int cmd_net_connect(const struct shell *sh, size_t argc, char **argv)
+static int cmd_modem_ppp_connect(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -472,7 +472,7 @@ static int cmd_net_connect(const struct shell *sh, size_t argc, char **argv)
 	return ret;
 }
 
-static int cmd_net_disconnect(const struct shell *sh, size_t argc, char **argv)
+static int cmd_modem_ppp_disconnect(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -485,7 +485,7 @@ static int cmd_net_disconnect(const struct shell *sh, size_t argc, char **argv)
 	return ret;
 }
 
-static int cmd_net_status(const struct shell *sh, size_t argc, char **argv)
+static int cmd_modem_ppp_status(const struct shell *sh, size_t argc, char **argv)
 {
 	int ret;
 	struct modem_net_ops ops;
@@ -496,11 +496,13 @@ static int cmd_net_status(const struct shell *sh, size_t argc, char **argv)
 	return ret;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_net,
-	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: connect <apn>", cmd_net_connect, 1, 1),
-	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_net_disconnect, 1, 0),
-	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_net_status, 1, 0),
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem_ppp,
+	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: ppp connect <apn>", cmd_modem_ppp_connect, 1, 1),
+	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_modem_ppp_disconnect, 1, 0),
+	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_modem_ppp_status, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 
-SHELL_CMD_REGISTER(net, &sub_net, "PPP network control", NULL);
+SHELL_SUBCMD_ADD((modem), ppp, &sub_modem_ppp,
+		 "Modem PPP control.",
+		 cmd_modem_ppp_status, 1, 0);

--- a/platform/src/modem-shell/CMakeLists.txt
+++ b/platform/src/modem-shell/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(${LIBRARY_NAME_OBJ} OBJECT)
 
 target_include_directories(${LIBRARY_NAME_OBJ} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${PLATFORM_SRC_DIR}/modem-net
   # ${PLATFORM_SRC_DIR}/modem-at/inc
 )
 

--- a/platform/src/modem-shell/modem-shell-uart.h
+++ b/platform/src/modem-shell/modem-shell-uart.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum modem_uart_owner {
+	MODEM_UART_OWNER_NONE = 0,
+	MODEM_UART_OWNER_AT,
+	MODEM_UART_OWNER_PASSTHROUGH,
+	MODEM_UART_OWNER_PPP,
+};
+
+int modem_uart_owner_acquire(enum modem_uart_owner owner);
+void modem_uart_owner_release(enum modem_uart_owner owner);
+enum modem_uart_owner modem_uart_owner_get(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -1,4 +1,5 @@
 #include "modem-shell-core.h"
+#include "modem-shell-uart.h"
 
 #include "modem-at.h"
 #include "modem-board.h"
@@ -67,13 +68,7 @@ static struct ring_buf modemUartRxRing;
 static bool modemUartRxIrqConfigured;
 static const struct shell *modemAtDebugShell;
 
-enum modem_uart_rx_owner {
-	MODEM_UART_RX_OWNER_NONE = 0,
-	MODEM_UART_RX_OWNER_AT,
-	MODEM_UART_RX_OWNER_PASSTHROUGH,
-};
-
-static enum modem_uart_rx_owner modemUartRxOwner;
+static enum modem_uart_owner modemUartRxOwner;
 
 static void modem_uart_rx_irq_cb(const struct device *dev, void *user_data);
 
@@ -94,24 +89,48 @@ static int modem_uart_rx_prepare(void)
 	return 0;
 }
 
-static int modem_uart_rx_acquire(enum modem_uart_rx_owner owner)
+int modem_uart_owner_acquire(enum modem_uart_owner owner)
+{
+	if (modemUartRxOwner != MODEM_UART_OWNER_NONE) {
+		return -EBUSY;
+	}
+
+	modemUartRxOwner = owner;
+	return 0;
+}
+
+void modem_uart_owner_release(enum modem_uart_owner owner)
+{
+	if (modemUartRxOwner != owner) {
+		return;
+	}
+
+	modemUartRxOwner = MODEM_UART_OWNER_NONE;
+}
+
+enum modem_uart_owner modem_uart_owner_get(void)
+{
+	return modemUartRxOwner;
+}
+
+static int modem_uart_rx_acquire(enum modem_uart_owner owner)
 {
 	int ret = modem_uart_rx_prepare();
 	if (ret != 0) {
 		return ret;
 	}
 
-	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
-		return -EBUSY;
+	ret = modem_uart_owner_acquire(owner);
+	if (ret != 0) {
+		return ret;
 	}
 
-	modemUartRxOwner = owner;
 	ring_buf_reset(&modemUartRxRing);
 	uart_irq_rx_enable(modemUart);
 	return 0;
 }
 
-static void modem_uart_rx_release(enum modem_uart_rx_owner owner)
+static void modem_uart_rx_release(enum modem_uart_owner owner)
 {
 	if (modemUartRxOwner != owner) {
 		return;
@@ -119,7 +138,7 @@ static void modem_uart_rx_release(enum modem_uart_rx_owner owner)
 
 	uart_irq_rx_disable(modemUart);
 	ring_buf_reset(&modemUartRxRing);
-	modemUartRxOwner = MODEM_UART_RX_OWNER_NONE;
+	modem_uart_owner_release(owner);
 }
 
 static uint32_t modem_uart_rx_read(void *ctx, uint8_t *buffer, size_t bufferSize)
@@ -136,7 +155,7 @@ static int modem_uart_irq_at_session_open(void *ctx, char *response, size_t resp
 		return -EINVAL;
 	}
 
-	int ret = modem_uart_rx_acquire(MODEM_UART_RX_OWNER_AT);
+	int ret = modem_uart_rx_acquire(MODEM_UART_OWNER_AT);
 	if (ret != 0) {
 		return ret;
 	}
@@ -148,7 +167,7 @@ static int modem_uart_irq_at_session_open(void *ctx, char *response, size_t resp
 static void modem_uart_irq_at_session_close(void *ctx)
 {
 	ARG_UNUSED(ctx);
-	modem_uart_rx_release(MODEM_UART_RX_OWNER_AT);
+	modem_uart_rx_release(MODEM_UART_OWNER_AT);
 }
 
 static void modem_at_debug_log_adapter(void *ctx, const char *fmt, ...)
@@ -236,7 +255,7 @@ static void modem_passthrough_stop(void)
 	}
 
 	passthroughActive = false;
-	modem_uart_rx_release(MODEM_UART_RX_OWNER_PASSTHROUGH);
+	modem_uart_rx_release(MODEM_UART_OWNER_PASSTHROUGH);
 	shell_set_bypass(passthroughShell, NULL);
 	shell_print(passthroughShell, "\r\n[modem passthrough disabled]");
 	passthroughShell = NULL;
@@ -412,7 +431,7 @@ static int cmd_modem_power(const struct shell *sh, size_t argc, char **argv)
 {
 	if ((argc >= 2U) &&
 	    ((strcmp(argv[1], "on") == 0) || (strcmp(argv[1], "cycle") == 0)) &&
-	    (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE)) {
+	    (modemUartRxOwner != MODEM_UART_OWNER_NONE)) {
 		shell_error(sh, "modem UART RX is busy");
 		return -EBUSY;
 	}
@@ -424,7 +443,7 @@ static int cmd_modem_power(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_modem_at(const struct shell *sh, size_t argc, char **argv)
 {
-	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
+	if (modemUartRxOwner != MODEM_UART_OWNER_NONE) {
 		shell_error(sh, "modem UART RX is busy");
 		return -EBUSY;
 	}
@@ -473,7 +492,7 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 		return -EBUSY;
 	}
 
-	if (modemUartRxOwner != MODEM_UART_RX_OWNER_NONE) {
+	if (modemUartRxOwner != MODEM_UART_OWNER_NONE) {
 		shell_error(sh, "modem UART RX is busy");
 		return -EBUSY;
 	}
@@ -492,7 +511,7 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 		passthroughThreadStarted = true;
 	}
 
-	ret = modem_uart_rx_acquire(MODEM_UART_RX_OWNER_PASSTHROUGH);
+	ret = modem_uart_rx_acquire(MODEM_UART_OWNER_PASSTHROUGH);
 	if (ret != 0) {
 		shell_error(sh, "failed to acquire modem UART IRQ RX: %d", ret);
 		return ret;

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -544,7 +544,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD_ARG(passthrough, NULL,
 		      "Raw UART passthrough to modem. Use --debug for RX trace mode; Ctrl-X then Ctrl-Q exits.",
 		      cmd_modem_passthrough, 1, 1),
-	SHELL_CMD_ARG(ppp, &sub_modem_ppp, "Modem PPP control", cmd_modem_ppp_status, 1, 0),
+	SHELL_CMD_ARG(ppp, &sub_modem_ppp, "Modem PPP control", NULL, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminator */
 );
 

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -1,5 +1,6 @@
 #include "modem-shell-core.h"
 #include "modem-shell-uart.h"
+#include "modem-net-shell.h"
 
 #include "modem-at.h"
 #include "modem-board.h"
@@ -528,6 +529,13 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 	return 0;
 }
 
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem_ppp,
+	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: ppp connect <apn>", cmd_modem_ppp_connect, 1, 1),
+	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_modem_ppp_disconnect, 1, 0),
+	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_modem_ppp_status, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD(status, NULL, "Print modem GPIO status", cmd_modem_status),
 	SHELL_CMD(reset, NULL, "Pulse modem reset (MODEM_nRST)", cmd_modem_reset),
@@ -536,6 +544,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD_ARG(passthrough, NULL,
 		      "Raw UART passthrough to modem. Use --debug for RX trace mode; Ctrl-X then Ctrl-Q exits.",
 		      cmd_modem_passthrough, 1, 1),
+	SHELL_CMD_ARG(ppp, &sub_modem_ppp, "Modem PPP control", cmd_modem_ppp_status, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminator */
 );
 

--- a/platform/src/modem-shell/modem-shell.c
+++ b/platform/src/modem-shell/modem-shell.c
@@ -530,7 +530,7 @@ static int cmd_modem_passthrough(const struct shell *sh, size_t argc, char **arg
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem_ppp,
-	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: ppp connect <apn>", cmd_modem_ppp_connect, 1, 1),
+	SHELL_CMD_ARG(connect, NULL, "Bring up modem PPP link: ppp connect <apn> <id> <password>", cmd_modem_ppp_connect, 4, 0),
 	SHELL_CMD_ARG(disconnect, NULL, "Tear down modem PPP link", cmd_modem_ppp_disconnect, 1, 0),
 	SHELL_CMD_ARG(status, NULL, "Show modem PPP status", cmd_modem_ppp_status, 1, 0),
 	SHELL_SUBCMD_SET_END
@@ -544,7 +544,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD_ARG(passthrough, NULL,
 		      "Raw UART passthrough to modem. Use --debug for RX trace mode; Ctrl-X then Ctrl-Q exits.",
 		      cmd_modem_passthrough, 1, 1),
-	SHELL_CMD_ARG(ppp, &sub_modem_ppp, "Modem PPP control", NULL, 1, 0),
+	SHELL_CMD_ARG(ppp, &sub_modem_ppp, "Modem PPP control", NULL, 0, 0),
 	SHELL_SUBCMD_SET_END /* Array terminator */
 );
 

--- a/platform/tests/catch2/CMakeLists.txt
+++ b/platform/tests/catch2/CMakeLists.txt
@@ -39,3 +39,11 @@ configure_catch2_test_target(platform_catch2_modem_shell
     ${PLATFORM_SRC_DIR}/modem-board/inc
     ${PLATFORM_SRC_DIR}/modem-shell
 )
+
+configure_catch2_test_target(platform_catch2_modem_net
+  SOURCES
+    ${PLATFORM_SRC_DIR}/modem-net/modem-net-core.c
+    ${CMAKE_CURRENT_LIST_DIR}/modem-net/test_modem_net_core.cpp
+  INCLUDE_DIRS
+    ${PLATFORM_SRC_DIR}/modem-net
+)

--- a/platform/tests/catch2/modem-net/test_modem_net_core.cpp
+++ b/platform/tests/catch2/modem-net/test_modem_net_core.cpp
@@ -1,0 +1,282 @@
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+extern "C" {
+#include "modem-net-core.h"
+}
+
+namespace {
+
+struct Capture {
+  std::string lastPrint;
+  std::string lastError;
+};
+
+struct State {
+  int owner = 0;
+  int ensurePoweredRet = 0;
+  int configureRet = 0;
+  int openRet = 0;
+  int dialRet = 0;
+  int attachRet = 0;
+  int waitRet = 0;
+  bool sessionOpen = false;
+  bool connected = false;
+  bool dnsReady = false;
+  bool modemPowered = true;
+  int lastError = 0;
+  std::string lastErrorText;
+  std::string apn;
+  std::string ipv4;
+  int closeCalls = 0;
+  int hangupCalls = 0;
+  Capture capture;
+};
+
+State g_state;
+
+void reset_state()
+{
+  g_state = State{};
+}
+
+int fake_owner_get()
+{
+  return g_state.owner;
+}
+
+int fake_ensure_powered(void *)
+{
+  return g_state.ensurePoweredRet;
+}
+
+int fake_configure_context(void *, const char *apn)
+{
+  if (g_state.configureRet == 0) {
+    g_state.apn = apn != nullptr ? apn : "";
+  }
+  return g_state.configureRet;
+}
+
+int fake_open_uart_session()
+{
+  if (g_state.openRet == 0) {
+    g_state.sessionOpen = true;
+  }
+  return g_state.openRet;
+}
+
+int fake_dial_ppp(void *)
+{
+  return g_state.dialRet;
+}
+
+int fake_attach_ppp()
+{
+  if (g_state.attachRet == 0) {
+    g_state.connected = true;
+  }
+  return g_state.attachRet;
+}
+
+int fake_wait_for_network(void *)
+{
+  if (g_state.waitRet == 0) {
+    g_state.connected = true;
+    g_state.dnsReady = true;
+    g_state.ipv4 = "10.0.0.2";
+  }
+  return g_state.waitRet;
+}
+
+void fake_close_uart_session()
+{
+  g_state.closeCalls++;
+  g_state.sessionOpen = false;
+  g_state.connected = false;
+  g_state.dnsReady = false;
+  g_state.ipv4.clear();
+}
+
+int fake_escape_and_hangup()
+{
+  g_state.hangupCalls++;
+  return 0;
+}
+
+int fake_get_status(struct modem_net_status *out)
+{
+  if (out == nullptr) {
+    return -22;
+  }
+
+  out->modemPowered = g_state.modemPowered;
+  out->sessionOpen = g_state.sessionOpen;
+  out->connected = g_state.connected;
+  out->dnsReady = g_state.dnsReady;
+  out->uartOwner = g_state.owner;
+  out->lastError = g_state.lastError;
+  out->lastErrorText = g_state.lastErrorText.empty() ? nullptr : g_state.lastErrorText.c_str();
+  out->apn = g_state.apn.empty() ? nullptr : g_state.apn.c_str();
+  out->ipv4 = g_state.ipv4.empty() ? nullptr : g_state.ipv4.c_str();
+  return 0;
+}
+
+void fake_set_apn(const char *apn)
+{
+  g_state.apn = apn != nullptr ? apn : "";
+}
+
+void fake_set_error(int error, const char *message)
+{
+  g_state.lastError = error;
+  g_state.lastErrorText = message != nullptr ? message : "";
+}
+
+void fake_clear_error()
+{
+  g_state.lastError = 0;
+  g_state.lastErrorText.clear();
+}
+
+void fake_print(void *ctx, const char *fmt, ...)
+{
+  auto *capture = static_cast<Capture *>(ctx);
+  char buffer[256];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  capture->lastPrint = buffer;
+}
+
+void fake_error(void *ctx, const char *fmt, ...)
+{
+  auto *capture = static_cast<Capture *>(ctx);
+  char buffer[256];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  capture->lastError = buffer;
+}
+
+modem_net_ops make_ops()
+{
+  return modem_net_ops{
+      fake_owner_get,
+      fake_ensure_powered,
+      fake_configure_context,
+      fake_open_uart_session,
+      fake_dial_ppp,
+      fake_attach_ppp,
+      fake_wait_for_network,
+      fake_close_uart_session,
+      fake_escape_and_hangup,
+      fake_get_status,
+      fake_set_apn,
+      fake_set_error,
+      fake_clear_error,
+      fake_print,
+      fake_error,
+      &g_state.capture,
+  };
+}
+
+} // namespace
+
+TEST_CASE("net connect requires an APN", "[modem-net]")
+{
+  reset_state();
+  auto ops = make_ops();
+  char *argv[] = {const_cast<char *>("connect")};
+
+  REQUIRE(modem_net_cmd_connect_core(&ops, 1, argv) == -22);
+  REQUIRE(g_state.capture.lastError == "usage: net connect <apn>");
+  REQUIRE(g_state.lastError == -22);
+  REQUIRE(g_state.lastErrorText == "APN required");
+}
+
+TEST_CASE("net connect rejects a busy modem UART", "[modem-net]")
+{
+  reset_state();
+  g_state.owner = 3;
+  auto ops = make_ops();
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+
+  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == -16);
+  REQUIRE(g_state.capture.lastError == "modem UART is busy");
+  REQUIRE(g_state.lastError == -16);
+}
+
+TEST_CASE("net connect reports PPP connected after full success path", "[modem-net]")
+{
+  reset_state();
+  auto ops = make_ops();
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+
+  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == 0);
+  REQUIRE(g_state.apn == "internet");
+  REQUIRE(g_state.capture.lastPrint == "PPP connected");
+  REQUIRE(g_state.closeCalls == 0);
+  REQUIRE(g_state.hangupCalls == 0);
+}
+
+TEST_CASE("net connect tears down on post-open failure", "[modem-net]")
+{
+  reset_state();
+  g_state.waitRet = -110;
+  auto ops = make_ops();
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+
+  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == -110);
+  REQUIRE(g_state.hangupCalls == 1);
+  REQUIRE(g_state.closeCalls == 1);
+  REQUIRE(g_state.capture.lastError == "connect failed: -110");
+  REQUIRE(g_state.lastError == -110);
+  REQUIRE(g_state.lastErrorText == "connect failed");
+}
+
+TEST_CASE("net disconnect is idempotent when already down", "[modem-net]")
+{
+  reset_state();
+  auto ops = make_ops();
+
+  REQUIRE(modem_net_cmd_disconnect_core(&ops, 1, nullptr) == 0);
+  REQUIRE(g_state.capture.lastPrint == "PPP already disconnected");
+  REQUIRE(g_state.closeCalls == 0);
+}
+
+TEST_CASE("net disconnect closes an active PPP session", "[modem-net]")
+{
+  reset_state();
+  g_state.sessionOpen = true;
+  g_state.connected = true;
+  auto ops = make_ops();
+
+  REQUIRE(modem_net_cmd_disconnect_core(&ops, 1, nullptr) == 0);
+  REQUIRE(g_state.hangupCalls == 1);
+  REQUIRE(g_state.closeCalls == 1);
+  REQUIRE(g_state.capture.lastPrint == "PPP disconnected");
+}
+
+TEST_CASE("net status prints current PPP details", "[modem-net]")
+{
+  reset_state();
+  g_state.modemPowered = true;
+  g_state.sessionOpen = true;
+  g_state.connected = true;
+  g_state.dnsReady = true;
+  g_state.owner = 3;
+  g_state.apn = "internet";
+  g_state.ipv4 = "10.0.0.2";
+  g_state.lastError = -5;
+  g_state.lastErrorText = "connect failed";
+  auto ops = make_ops();
+
+  REQUIRE(modem_net_cmd_status_core(&ops, 1, nullptr) == 0);
+  REQUIRE(g_state.capture.lastPrint == "modem=on owner=ppp ppp=connected ip=10.0.0.2 dns=ready apn=internet last_error=-5 connect failed");
+}

--- a/platform/tests/catch2/modem-net/test_modem_net_core.cpp
+++ b/platform/tests/catch2/modem-net/test_modem_net_core.cpp
@@ -188,19 +188,19 @@ modem_net_ops make_ops()
 
 } // namespace
 
-TEST_CASE("net connect requires an APN", "[modem-net]")
+TEST_CASE("modem ppp connect requires an APN", "[modem-net]")
 {
   reset_state();
   auto ops = make_ops();
   char *argv[] = {const_cast<char *>("connect")};
 
   REQUIRE(modem_net_cmd_connect_core(&ops, 1, argv) == -22);
-  REQUIRE(g_state.capture.lastError == "usage: net connect <apn>");
+  REQUIRE(g_state.capture.lastError == "usage: modem ppp connect <apn>");
   REQUIRE(g_state.lastError == -22);
   REQUIRE(g_state.lastErrorText == "APN required");
 }
 
-TEST_CASE("net connect rejects a busy modem UART", "[modem-net]")
+TEST_CASE("modem ppp connect rejects a busy modem UART", "[modem-net]")
 {
   reset_state();
   g_state.owner = 3;
@@ -212,7 +212,7 @@ TEST_CASE("net connect rejects a busy modem UART", "[modem-net]")
   REQUIRE(g_state.lastError == -16);
 }
 
-TEST_CASE("net connect reports PPP connected after full success path", "[modem-net]")
+TEST_CASE("modem ppp connect reports PPP connected after full success path", "[modem-net]")
 {
   reset_state();
   auto ops = make_ops();
@@ -225,7 +225,7 @@ TEST_CASE("net connect reports PPP connected after full success path", "[modem-n
   REQUIRE(g_state.hangupCalls == 0);
 }
 
-TEST_CASE("net connect tears down on post-open failure", "[modem-net]")
+TEST_CASE("modem ppp connect tears down on post-open failure", "[modem-net]")
 {
   reset_state();
   g_state.waitRet = -110;
@@ -240,7 +240,7 @@ TEST_CASE("net connect tears down on post-open failure", "[modem-net]")
   REQUIRE(g_state.lastErrorText == "connect failed");
 }
 
-TEST_CASE("net disconnect is idempotent when already down", "[modem-net]")
+TEST_CASE("modem ppp disconnect is idempotent when already down", "[modem-net]")
 {
   reset_state();
   auto ops = make_ops();
@@ -250,7 +250,7 @@ TEST_CASE("net disconnect is idempotent when already down", "[modem-net]")
   REQUIRE(g_state.closeCalls == 0);
 }
 
-TEST_CASE("net disconnect closes an active PPP session", "[modem-net]")
+TEST_CASE("modem ppp disconnect closes an active PPP session", "[modem-net]")
 {
   reset_state();
   g_state.sessionOpen = true;
@@ -263,7 +263,7 @@ TEST_CASE("net disconnect closes an active PPP session", "[modem-net]")
   REQUIRE(g_state.capture.lastPrint == "PPP disconnected");
 }
 
-TEST_CASE("net status prints current PPP details", "[modem-net]")
+TEST_CASE("modem ppp status prints current PPP details", "[modem-net]")
 {
   reset_state();
   g_state.modemPowered = true;

--- a/platform/tests/catch2/modem-net/test_modem_net_core.cpp
+++ b/platform/tests/catch2/modem-net/test_modem_net_core.cpp
@@ -256,6 +256,7 @@ TEST_CASE("modem ppp connect tears down on post-open failure", "[modem-net]")
       "PPP connect: dial PPP",
       "PPP connect: attach PPP",
       "PPP connect: wait for network",
+      "PPP network wait timed out, tearing down session...",
   });
   REQUIRE(g_state.capture.lastError == "connect failed at wait_for_network: -110");
   REQUIRE(g_state.lastError == -110);

--- a/platform/tests/catch2/modem-net/test_modem_net_core.cpp
+++ b/platform/tests/catch2/modem-net/test_modem_net_core.cpp
@@ -33,6 +33,8 @@ struct State {
   int lastError = 0;
   std::string lastErrorText;
   std::string apn;
+  std::string id;
+  std::string password;
   std::string ipv4;
   int closeCalls = 0;
   int hangupCalls = 0;
@@ -56,10 +58,12 @@ int fake_ensure_powered(void *)
   return g_state.ensurePoweredRet;
 }
 
-int fake_configure_context(void *, const char *apn)
+int fake_configure_context(void *, const modem_net_profile *prof)
 {
-  if (g_state.configureRet == 0) {
-    g_state.apn = apn != nullptr ? apn : "";
+  if (g_state.configureRet == 0 && prof != nullptr) {
+    g_state.apn = prof->apn != nullptr ? prof->apn : "";
+    g_state.id = prof->id != nullptr ? prof->id : "";
+    g_state.password = prof->password != nullptr ? prof->password : "";
   }
   return g_state.configureRet;
 }
@@ -193,16 +197,16 @@ modem_net_ops make_ops()
 
 } // namespace
 
-TEST_CASE("modem ppp connect requires an APN", "[modem-net]")
+TEST_CASE("modem ppp connect requires APN, id, and password", "[modem-net]")
 {
   reset_state();
   auto ops = make_ops();
   char *argv[] = {const_cast<char *>("connect")};
 
   REQUIRE(modem_net_cmd_connect_core(&ops, 1, argv) == -22);
-  REQUIRE(g_state.capture.lastError == "usage: modem ppp connect <apn>");
+  REQUIRE(g_state.capture.lastError == "usage: modem ppp connect <apn> <id> <password>");
   REQUIRE(g_state.lastError == -22);
-  REQUIRE(g_state.lastErrorText == "APN required");
+  REQUIRE(g_state.lastErrorText == "APN/ID/PASS required");
 }
 
 TEST_CASE("modem ppp connect rejects a busy modem UART", "[modem-net]")
@@ -210,9 +214,9 @@ TEST_CASE("modem ppp connect rejects a busy modem UART", "[modem-net]")
   reset_state();
   g_state.owner = 3;
   auto ops = make_ops();
-  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet"), const_cast<char *>("user"), const_cast<char *>("pass")};
 
-  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == -16);
+  REQUIRE(modem_net_cmd_connect_core(&ops, 4, argv) == -16);
   REQUIRE(g_state.capture.lastError == "modem UART is busy");
   REQUIRE(g_state.lastError == -16);
 }
@@ -221,10 +225,12 @@ TEST_CASE("modem ppp connect reports PPP connected after full success path", "[m
 {
   reset_state();
   auto ops = make_ops();
-  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet"), const_cast<char *>("user"), const_cast<char *>("pass")};
 
-  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == 0);
+  REQUIRE(modem_net_cmd_connect_core(&ops, 4, argv) == 0);
   REQUIRE(g_state.apn == "internet");
+  REQUIRE(g_state.id == "user");
+  REQUIRE(g_state.password == "pass");
   REQUIRE(g_state.capture.lastPrint == "PPP connected");
   REQUIRE(g_state.capture.prints == std::vector<std::string>{
       "PPP connect: ensure modem powered",
@@ -244,9 +250,9 @@ TEST_CASE("modem ppp connect tears down on post-open failure", "[modem-net]")
   reset_state();
   g_state.waitRet = -110;
   auto ops = make_ops();
-  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet")};
+  char *argv[] = {const_cast<char *>("connect"), const_cast<char *>("internet"), const_cast<char *>("user"), const_cast<char *>("pass")};
 
-  REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == -110);
+  REQUIRE(modem_net_cmd_connect_core(&ops, 4, argv) == -110);
   REQUIRE(g_state.hangupCalls == 1);
   REQUIRE(g_state.closeCalls == 1);
   REQUIRE(g_state.capture.prints == std::vector<std::string>{

--- a/platform/tests/catch2/modem-net/test_modem_net_core.cpp
+++ b/platform/tests/catch2/modem-net/test_modem_net_core.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <string>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -13,6 +14,8 @@ namespace {
 struct Capture {
   std::string lastPrint;
   std::string lastError;
+  std::vector<std::string> prints;
+  std::vector<std::string> errors;
 };
 
 struct State {
@@ -151,6 +154,7 @@ void fake_print(void *ctx, const char *fmt, ...)
   vsnprintf(buffer, sizeof(buffer), fmt, args);
   va_end(args);
   capture->lastPrint = buffer;
+  capture->prints.emplace_back(buffer);
 }
 
 void fake_error(void *ctx, const char *fmt, ...)
@@ -162,6 +166,7 @@ void fake_error(void *ctx, const char *fmt, ...)
   vsnprintf(buffer, sizeof(buffer), fmt, args);
   va_end(args);
   capture->lastError = buffer;
+  capture->errors.emplace_back(buffer);
 }
 
 modem_net_ops make_ops()
@@ -221,6 +226,15 @@ TEST_CASE("modem ppp connect reports PPP connected after full success path", "[m
   REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == 0);
   REQUIRE(g_state.apn == "internet");
   REQUIRE(g_state.capture.lastPrint == "PPP connected");
+  REQUIRE(g_state.capture.prints == std::vector<std::string>{
+      "PPP connect: ensure modem powered",
+      "PPP connect: configure PDP/APN context",
+      "PPP connect: open UART session",
+      "PPP connect: dial PPP",
+      "PPP connect: attach PPP",
+      "PPP connect: wait for network",
+      "PPP connected",
+  });
   REQUIRE(g_state.closeCalls == 0);
   REQUIRE(g_state.hangupCalls == 0);
 }
@@ -235,7 +249,15 @@ TEST_CASE("modem ppp connect tears down on post-open failure", "[modem-net]")
   REQUIRE(modem_net_cmd_connect_core(&ops, 2, argv) == -110);
   REQUIRE(g_state.hangupCalls == 1);
   REQUIRE(g_state.closeCalls == 1);
-  REQUIRE(g_state.capture.lastError == "connect failed: -110");
+  REQUIRE(g_state.capture.prints == std::vector<std::string>{
+      "PPP connect: ensure modem powered",
+      "PPP connect: configure PDP/APN context",
+      "PPP connect: open UART session",
+      "PPP connect: dial PPP",
+      "PPP connect: attach PPP",
+      "PPP connect: wait for network",
+  });
+  REQUIRE(g_state.capture.lastError == "connect failed at wait_for_network: -110");
   REQUIRE(g_state.lastError == -110);
   REQUIRE(g_state.lastErrorText == "connect failed");
 }


### PR DESCRIPTION
Fixes #6.

## Summary
- add a Zephyr-native PPP bring-up path in new `platform/src/modem-net/`
- make PPP a formal third modem UART owner alongside AT and passthrough
- add shell-facing `net connect`, `net disconnect`, and `net status` behavior through a host-testable core
- register the new modem-net platform unit and enable required PPP/network config in `control/prj.conf`
- add direct Catch2 coverage for the new modem-net shell/session core

## Notes
- implementation stays thin and leans on Zephyr `modem_backend_uart` + `modem_ppp`
- no CMUX yet; this is PPP-over-UART first as scoped in the issue
- `CONFIG_NUM_COOP_PRIORITIES` is raised to `1` because Zephyr PPP/network traffic classes require at least one cooperative priority

## Validation
- `cmake -S platform/tests/catch2 -B platform/tests/catch2/build`
- `cmake --build platform/tests/catch2/build -j2`
- `ctest --test-dir platform/tests/catch2/build --output-on-failure`
- `west build control -p auto -b control@a4 --shield sense_a3 -d control/build`
